### PR TITLE
added .gitignore for Eclipse & IntelliJ users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+*.class
+
+# Intellij
+.idea/
+*.iml
+*.iws
+*.eml
+out/
+
+# Eclipse
+*.pydevproject
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.classpath
+.project
+RemoteSystemsTempFiles/
+.externalToolBuilders/
+*.launch
+.cproject
+.buildpath


### PR DESCRIPTION
I'd recommend to put the /dist folder into .gitignore as well. For example /dist/lib dupes the /lib folder, thus taking up more space and confusing IDEs on project import