### PR TITLE
Fix NullPointerException with POST request

### DIFF
--- a/src/org/mozilla/zest/impl/ZestBasicRunner.java
+++ b/src/org/mozilla/zest/impl/ZestBasicRunner.java
@@ -484,7 +484,9 @@ public class ZestBasicRunner implements ZestRunner, ZestRuntime {
 			
 			((PostMethod) method).setRequestEntity(requestEntity);
 			
-			method.setRequestHeader(contentType);
+			if (contentType != null) {
+				method.setRequestHeader(contentType);
+			}
 		}
 		
 		int code = 0;


### PR DESCRIPTION
Change ZestBasicRunner to only set the Content-Type of the POST request
if it was defined, preventing the NullPointerException.

Related to zaproxy/zaproxy#2859 - NullPointerException with a POST
request in a Zest script