### PR TITLE
Use variables in the order they were added

### DIFF
--- a/src/org/mozilla/zest/core/v1/ZestVariables.java
+++ b/src/org/mozilla/zest/core/v1/ZestVariables.java
@@ -7,7 +7,7 @@ package org.mozilla.zest.core.v1;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -45,7 +45,7 @@ public class ZestVariables extends ZestElement {
 	private String tokenEnd = "}}";
 	
 	/** The tokens. */
-	private Map<String, String> tokens = new HashMap<String, String>();
+	private Map<String, String> tokens = new LinkedHashMap<>();
 	
 	/**
 	 * Instantiates a new zest tokens.
@@ -116,11 +116,13 @@ public class ZestVariables extends ZestElement {
 
 	/**
 	 * Sets the tokens.
+	 * <p>
+	 * It's created a copy of the given map.
 	 *
 	 * @param tokens the tokens
 	 */
 	public void setVariable(Map<String, String> tokens) {
-		this.tokens = tokens;
+		this.tokens = new LinkedHashMap<>(tokens);
 	}
 	
 	/**

--- a/test/org/mozilla/zest/test/v1/ZestAllTestSuite.java
+++ b/test/org/mozilla/zest/test/v1/ZestAllTestSuite.java
@@ -43,7 +43,8 @@ import org.junit.runners.Suite.SuiteClasses;
 	ZestRequestUnitTest.class,
 	ZestScriptUnitTest.class,
 	ZestStructuredExpressionUnitTest.class,
-	ZestVariableUnitTest.class
+	ZestVariableUnitTest.class,
+	ZestVariablesUnitTest.class
 })
 
 public final class ZestAllTestSuite {

--- a/test/org/mozilla/zest/test/v1/ZestVariablesUnitTest.java
+++ b/test/org/mozilla/zest/test/v1/ZestVariablesUnitTest.java
@@ -246,10 +246,10 @@ public class ZestVariablesUnitTest {
         assertTrue(zestVars.getVariables().size() == 3);
         assertTrue(zestVars.getVariables().get(0)[0] == varName1);
         assertTrue(varValue1.equals(zestVars.getVariables().get(0)[1]));
-        assertTrue(varName2.equals(zestVars.getVariables().get(1)[0]));
-        assertTrue(varValue2.equals(zestVars.getVariables().get(1)[1]));
-        assertTrue(varName3.equals(zestVars.getVariables().get(2)[0]));
-        assertTrue(zestVars.getVariables().get(2)[1] == varValue3);
+        assertTrue(varName3.equals(zestVars.getVariables().get(1)[0]));
+        assertTrue(zestVars.getVariables().get(1)[1] == varValue3);
+        assertTrue(varName2.equals(zestVars.getVariables().get(2)[0]));
+        assertTrue(zestVars.getVariables().get(2)[1] == varValue2);
     }
 
     @Test


### PR DESCRIPTION
Change ZestVariables class to keep/use the variables in the order they
were added, ensuring that the variables are replaced always in the same
(expected) order.
Update test to assert the new behaviour.