### PR TITLE
Remove Mockito, unused

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,7 @@ dependencies {
              'org.seleniumhq.selenium:selenium-server:2.43.0',
              'net.htmlparser.jericho:jericho-html:3.1')
 
-    testCompile('junit:junit:4.11',
-                'org.mockito:mockito-all:1.9.0')
+    testCompile('junit:junit:4.11')
 }
 
 jar {

--- a/src/test/java/org/mozilla/zest/test/v1/ZestActionInvokeUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestActionInvokeUnitTest.java
@@ -10,8 +10,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestActionInvoke;
 import org.mozilla.zest.core.v1.ZestJSON;
 import org.mozilla.zest.core.v1.ZestResponse;
@@ -19,7 +17,6 @@ import org.mozilla.zest.core.v1.ZestResponse;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestActionInvokeUnitTest {
 
 	/**

--- a/src/test/java/org/mozilla/zest/test/v1/ZestActionSleepUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestActionSleepUnitTest.java
@@ -9,8 +9,6 @@ import static org.junit.Assert.assertEquals;
 import java.util.Date;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestActionSleep;
 import org.mozilla.zest.core.v1.ZestJSON;
 import org.mozilla.zest.core.v1.ZestResponse;
@@ -18,7 +16,6 @@ import org.mozilla.zest.core.v1.ZestResponse;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestActionSleepUnitTest {
 
 	/**

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssertBodyRegexUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssertBodyRegexUnitTest.java
@@ -8,8 +8,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestAssertion;
 import org.mozilla.zest.core.v1.ZestExpressionRegex;
 import org.mozilla.zest.core.v1.ZestResponse;
@@ -17,7 +15,6 @@ import org.mozilla.zest.core.v1.ZestVariables;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestAssertBodyRegexUnitTest {
 
 	/**

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignRegexDelimitersUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignRegexDelimitersUnitTest.java
@@ -8,8 +8,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestAssignFailException;
 import org.mozilla.zest.core.v1.ZestAssignRegexDelimiters;
 import org.mozilla.zest.core.v1.ZestResponse;
@@ -17,7 +15,6 @@ import org.mozilla.zest.core.v1.ZestResponse;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestAssignRegexDelimitersUnitTest {
 	
 	private TestRuntime rt = new TestRuntime();

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignReplaceUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignReplaceUnitTest.java
@@ -7,8 +7,6 @@ package org.mozilla.zest.test.v1;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestAssignReplace;
 import org.mozilla.zest.core.v1.ZestJSON;
 import org.mozilla.zest.core.v1.ZestResponse;
@@ -17,7 +15,6 @@ import org.mozilla.zest.core.v1.ZestVariables;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestAssignReplaceUnitTest {
 
 

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignStringDelimitersUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignStringDelimitersUnitTest.java
@@ -8,8 +8,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestAssignFailException;
 import org.mozilla.zest.core.v1.ZestAssignStringDelimiters;
 import org.mozilla.zest.core.v1.ZestJSON;
@@ -18,7 +16,6 @@ import org.mozilla.zest.core.v1.ZestResponse;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestAssignStringDelimitersUnitTest {
 
 	private TestRuntime rt = new TestRuntime();

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignStringUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignStringUnitTest.java
@@ -7,8 +7,6 @@ package org.mozilla.zest.test.v1;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestAssignString;
 import org.mozilla.zest.core.v1.ZestJSON;
 import org.mozilla.zest.core.v1.ZestResponse;
@@ -16,7 +14,6 @@ import org.mozilla.zest.core.v1.ZestResponse;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestAssignStringUnitTest {
 
 

--- a/src/test/java/org/mozilla/zest/test/v1/ZestClientLaunchUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestClientLaunchUnitTest.java
@@ -13,8 +13,6 @@ import java.net.InetSocketAddress;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestActionSleep;
 import org.mozilla.zest.core.v1.ZestClientFailException;
 import org.mozilla.zest.core.v1.ZestClientLaunch;
@@ -29,7 +27,6 @@ import com.sun.net.httpserver.HttpServer;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestClientLaunchUnitTest {
 
 	private static final int PORT = 8888;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexExprUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexExprUnitTest.java
@@ -11,8 +11,6 @@ package org.mozilla.zest.test.v1;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestConditional;
 import org.mozilla.zest.core.v1.ZestExpressionRegex;
 import org.mozilla.zest.core.v1.ZestRequest;
@@ -20,7 +18,6 @@ import org.mozilla.zest.core.v1.ZestStatement;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestConditionalRegexExprUnitTest {
 
 	/**

--- a/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexUnitTest.java
@@ -7,8 +7,6 @@ package org.mozilla.zest.test.v1;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestConditional;
 import org.mozilla.zest.core.v1.ZestExpressionRegex;
 import org.mozilla.zest.core.v1.ZestRequest;
@@ -17,7 +15,6 @@ import org.mozilla.zest.core.v1.ZestStatement;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestConditionalRegexUnitTest {
 
 	/**

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionIsIntegerUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionIsIntegerUnitTest.java
@@ -12,13 +12,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestExpressionIsInteger;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestExpressionIsIntegerUnitTest {
 
 	@Test

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionLengthUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionLengthUnitTest.java
@@ -14,14 +14,11 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestExpressionLength;
 import org.mozilla.zest.core.v1.ZestResponse;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestExpressionLengthUnitTest {
 public static ZestResponse response;
 static {

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionResponseTimeUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionResponseTimeUnitTest.java
@@ -11,14 +11,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestExpressionResponseTime;
 import org.mozilla.zest.core.v1.ZestResponse;
 import org.mozilla.zest.core.v1.ZestRuntime;
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestExpressionResponseTimeUnitTest {
 
 	@Test

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionURLUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionURLUnitTest.java
@@ -16,15 +16,12 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestExpressionURL;
 import org.mozilla.zest.core.v1.ZestRequest;
 import org.mozilla.zest.core.v1.ZestResponse;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestExpressionURLUnitTest {
 
 	List<String> includeStrings = new LinkedList<>();

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopClientElementUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopClientElementUnitTest.java
@@ -14,8 +14,6 @@ import java.net.InetSocketAddress;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestActionPrint;
 import org.mozilla.zest.core.v1.ZestClientLaunch;
 import org.mozilla.zest.core.v1.ZestClientWindowClose;
@@ -30,7 +28,6 @@ import com.sun.net.httpserver.HttpServer;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestLoopClientElementUnitTest {
 
 	private static final int PORT = 8888;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopIntegerUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopIntegerUnitTest.java
@@ -14,8 +14,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestActionPrint;
 import org.mozilla.zest.core.v1.ZestConditional;
 import org.mozilla.zest.core.v1.ZestControlLoopBreak;
@@ -26,7 +24,6 @@ import org.mozilla.zest.core.v1.ZestStatement;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestLoopIntegerUnitTest {
 	static String[] values = { "a", "b", "c" };
 	static List<ZestStatement> statements = new LinkedList<>();

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopSerializationUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopSerializationUnitTest.java
@@ -14,8 +14,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestConditional;
 import org.mozilla.zest.core.v1.ZestExpressionResponseTime;
 import org.mozilla.zest.core.v1.ZestExpressionStatusCode;
@@ -25,7 +23,6 @@ import org.mozilla.zest.core.v1.ZestLoopInteger;
 import org.mozilla.zest.core.v1.ZestLoopString;
 import org.mozilla.zest.core.v1.ZestStatement;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ZestLoopSerializationUnitTest {
 	String[] values={"a","b","c"};
 	List<ZestStatement> statements=new LinkedList<>();

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopStateUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopStateUnitTest.java
@@ -12,14 +12,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestLoopStateString;
 import org.mozilla.zest.core.v1.ZestLoopTokenStringSet;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestLoopStateUnitTest {
 	String[] values = { "A", "B", "C", "D", "D" };
 	ZestLoopTokenStringSet set = new ZestLoopTokenStringSet(values);

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopStringUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopStringUnitTest.java
@@ -16,8 +16,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestActionFail;
 import org.mozilla.zest.core.v1.ZestAssignString;
 import org.mozilla.zest.core.v1.ZestConditional;
@@ -30,7 +28,6 @@ import org.mozilla.zest.impl.ZestBasicRunner;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestLoopStringUnitTest {
 	String[] values = { "1", "2", "3", "4", "5", "6", "7" };
 

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopTokenSetUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopTokenSetUnitTest.java
@@ -11,13 +11,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestLoopTokenSet;
 import org.mozilla.zest.core.v1.ZestLoopTokenStringSet;
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestLoopTokenSetUnitTest {
 	String[] arrayValueS={"A","B","C","D","D"};
 	Integer[] arrayValueI={1,2,3,4,5,4,5};

--- a/src/test/java/org/mozilla/zest/test/v1/ZestRequestUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestRequestUnitTest.java
@@ -9,15 +9,12 @@ import static org.junit.Assert.assertEquals;
 import java.net.URL;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestRequest;
 import org.mozilla.zest.core.v1.ZestVariables;
 
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestRequestUnitTest {
 
 	/**

--- a/src/test/java/org/mozilla/zest/test/v1/ZestScriptUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestScriptUnitTest.java
@@ -8,8 +8,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestAssignFieldValue;
 import org.mozilla.zest.core.v1.ZestAssignStringDelimiters;
 import org.mozilla.zest.core.v1.ZestConditional;
@@ -22,7 +20,6 @@ import org.mozilla.zest.core.v1.ZestVariables;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestScriptUnitTest {
 	
 	/**

--- a/src/test/java/org/mozilla/zest/test/v1/ZestStructuredExpressionUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestStructuredExpressionUnitTest.java
@@ -18,8 +18,6 @@ import java.util.List;
 import java.util.Random;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestConditional;
 import org.mozilla.zest.core.v1.ZestExpression;
 import org.mozilla.zest.core.v1.ZestExpressionAnd;
@@ -36,7 +34,6 @@ import org.mozilla.zest.core.v1.ZestVariables;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestStructuredExpressionUnitTest {
 	@Test
 	public void testDeepCopySingleAndSameChildrenSize() {

--- a/src/test/java/org/mozilla/zest/test/v1/ZestVariableUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestVariableUnitTest.java
@@ -9,8 +9,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.Set;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mozilla.zest.core.v1.ZestAssignString;
 import org.mozilla.zest.core.v1.ZestLoopFile;
 import org.mozilla.zest.core.v1.ZestScript;
@@ -18,7 +16,6 @@ import org.mozilla.zest.core.v1.ZestScript;
 
 /**
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ZestVariableUnitTest {
 
 	/**


### PR DESCRIPTION
Remove Mockito from test dependencies.
Remove the RunWith (Mockito) annotation from the tests, not actually
used.