### PR TITLE
Remove "(non-Javadoc)" comments

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestAction.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAction.java
@@ -29,17 +29,11 @@ public abstract class ZestAction extends ZestStatement {
 		super(index);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isSameSubclass(org.mozilla.zest.core.v1.ZestElement)
-	 */
 	@Override
 	public boolean isSameSubclass(ZestElement ze) {
 		return ze instanceof ZestAction;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#setPrefix(java.lang.String, java.lang.String)
-	 */
 	@Override
 	void setPrefix(String oldPrefix, String newPrefix) throws MalformedURLException {
 		// Ignore

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionFail.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionFail.java
@@ -72,17 +72,11 @@ public class ZestActionFail extends ZestAction {
 		this.setPriority(priority);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestAction#isSameSubclass(org.mozilla.zest.core.v1.ZestElement)
-	 */
 	@Override
 	public boolean isSameSubclass(ZestElement ze) {
 		return ze instanceof ZestActionFail;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestAction#invoke(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public String invoke(ZestResponse response, ZestRuntime runtime) throws ZestActionFailException {
 		throw new ZestActionFailException(this, runtime.replaceVariablesInString(this.message, false));
@@ -138,9 +132,6 @@ public class ZestActionFail extends ZestAction {
 		this.priority = priority;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#deepCopy()
-	 */
 	@Override
 	public ZestActionFail deepCopy() {
 		ZestActionFail copy = new ZestActionFail(this.getIndex());
@@ -150,9 +141,6 @@ public class ZestActionFail extends ZestAction {
 		return copy;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isPassive()
-	 */
 	@Override
 	public boolean isPassive() {
 		return true;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionIntercept.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionIntercept.java
@@ -26,9 +26,6 @@ public class ZestActionIntercept extends ZestAction {
 		super(index);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#deepCopy()
-	 */
 	@Override
 	public ZestActionIntercept deepCopy() {
 		ZestActionIntercept copy = new ZestActionIntercept(this.getIndex());
@@ -36,18 +33,12 @@ public class ZestActionIntercept extends ZestAction {
 		return copy;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestAction#invoke(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public String invoke(ZestResponse response, ZestRuntime runtime) throws ZestActionFailException {
 		// Ignore
 		return "";
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isPassive()
-	 */
 	@Override
 	public boolean isPassive() {
 		return false;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionInvoke.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionInvoke.java
@@ -56,17 +56,11 @@ public class ZestActionInvoke extends ZestAction {
 		this.parameters = parameters;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestAction#isSameSubclass(org.mozilla.zest.core.v1.ZestElement)
-	 */
 	@Override
 	public boolean isSameSubclass(ZestElement ze) {
 		return ze instanceof ZestActionInvoke;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestAction#invoke(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public String invoke(ZestResponse response, ZestRuntime runtime) throws ZestActionFailException {
 		ScriptEngine engine = null;
@@ -178,9 +172,6 @@ public class ZestActionInvoke extends ZestAction {
 		this.parameters = parameters;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#deepCopy()
-	 */
 	@Override
 	public ZestActionInvoke deepCopy() {
 		ZestActionInvoke copy = new ZestActionInvoke(this.getIndex());
@@ -194,9 +185,6 @@ public class ZestActionInvoke extends ZestAction {
 		return copy;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isPassive()
-	 */
 	@Override
 	public boolean isPassive() {
 		return false;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionPrint.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionPrint.java
@@ -39,17 +39,11 @@ public class ZestActionPrint extends ZestAction {
 		this.message = message;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestAction#isSameSubclass(org.mozilla.zest.core.v1.ZestElement)
-	 */
 	@Override
 	public boolean isSameSubclass(ZestElement ze) {
 		return ze instanceof ZestActionPrint;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestAction#invoke(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public String invoke(ZestResponse response, ZestRuntime runtime) throws ZestActionFailException {
 		String str = runtime.replaceVariablesInString(this.message, false);
@@ -76,9 +70,6 @@ public class ZestActionPrint extends ZestAction {
 	}
 	
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#deepCopy()
-	 */
 	@Override
 	public ZestActionPrint deepCopy() {
 		ZestActionPrint copy = new ZestActionPrint(this.getIndex());
@@ -87,9 +78,6 @@ public class ZestActionPrint extends ZestAction {
 		return copy;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isPassive()
-	 */
 	@Override
 	public boolean isPassive() {
 		return true;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionScan.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionScan.java
@@ -57,9 +57,6 @@ public class ZestActionScan extends ZestAction {
 		this.targetParameter = targetParameter;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#deepCopy()
-	 */
 	@Override
 	public ZestActionScan deepCopy() {
 		ZestActionScan copy = new ZestActionScan(this.getIndex());
@@ -68,17 +65,11 @@ public class ZestActionScan extends ZestAction {
 		return copy;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestAction#invoke(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public String invoke(ZestResponse response, ZestRuntime runtime) throws ZestActionFailException {
 		throw new ZestActionFailException(this);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isPassive()
-	 */
 	@Override
 	public boolean isPassive() {
 		return false;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionSleep.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionSleep.java
@@ -39,17 +39,11 @@ public class ZestActionSleep extends ZestAction {
 		this.milliseconds = milliseconds;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestAction#isSameSubclass(org.mozilla.zest.core.v1.ZestElement)
-	 */
 	@Override
 	public boolean isSameSubclass(ZestElement ze) {
 		return ze instanceof ZestActionSleep;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestAction#invoke(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public String invoke(ZestResponse response, ZestRuntime runtime) throws ZestActionFailException {
 		try {
@@ -69,9 +63,6 @@ public class ZestActionSleep extends ZestAction {
 		this.milliseconds = milliseconds;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#deepCopy()
-	 */
 	@Override
 	public ZestActionSleep deepCopy() {
 		ZestActionSleep copy = new ZestActionSleep(this.getIndex());
@@ -80,9 +71,6 @@ public class ZestActionSleep extends ZestAction {
 		return copy;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isPassive()
-	 */
 	@Override
 	public boolean isPassive() {
 		return true;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssertion.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssertion.java
@@ -63,17 +63,11 @@ public class ZestAssertion extends ZestElement{
 		return rootExpression.evaluate(runtime);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestElement#isSameSubclass(org.mozilla.zest.core.v1.ZestElement)
-	 */
 	@Override
 	public boolean isSameSubclass(ZestElement ze) {
 		return ze instanceof ZestAssertion;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestElement#deepCopy()
-	 */
 	@Override
 	public ZestElement deepCopy() {
 		ZestExpressionElement copy_root_expr=(ZestExpressionElement)rootExpression.deepCopy();

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignCalc.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignCalc.java
@@ -47,9 +47,6 @@ public class ZestAssignCalc extends ZestAssignment {
 		this.operandB = operandB;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestTransformation#transform(org.mozilla.zest.core.v1.ZestRunner, org.mozilla.zest.core.v1.ZestRequest)
-	 */
 	@Override
 	public String assign (ZestResponse response, ZestRuntime runtime) throws ZestAssignFailException {
 		int operA;
@@ -76,9 +73,6 @@ public class ZestAssignCalc extends ZestAssignment {
 		throw new ZestAssignFailException(this, "Invalid operation");
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestElement#deepCopy()
-	 */
 	@Override
 	public ZestAssignCalc deepCopy() {
 		ZestAssignCalc copy = new ZestAssignCalc(this.getVariableName(), operandA, operation, operandB);

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignFieldValue.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignFieldValue.java
@@ -45,9 +45,6 @@ public class ZestAssignFieldValue extends ZestAssignment {
 		this.fieldDefinition = fieldDefinition;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestElement#deepCopy()
-	 */
 	@Override
 	public ZestAssignFieldValue deepCopy() {
 		ZestAssignFieldValue copy = new ZestAssignFieldValue(this.getVariableName(), this.fieldDefinition.deepCopy());
@@ -73,9 +70,6 @@ public class ZestAssignFieldValue extends ZestAssignment {
 		this.fieldDefinition = fieldDefinition;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestAssignment#assign(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public String assign(ZestResponse response, ZestRuntime runtime) throws ZestAssignFailException {
 		Source src = new Source(response.getHeaders() + response.getBody());

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignRandomInteger.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignRandomInteger.java
@@ -49,18 +49,12 @@ public class ZestAssignRandomInteger extends ZestAssignment {
 		this.maxInt = maxInt;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestTransformation#transform(org.mozilla.zest.core.v1.ZestRunner, org.mozilla.zest.core.v1.ZestRequest)
-	 */
 	@Override
 	public String assign (ZestResponse response, ZestRuntime runtime) throws ZestAssignFailException {
 		int val = minInt + rnd.nextInt(maxInt - minInt);
 		return Integer.toString(val);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestElement#deepCopy()
-	 */
 	@Override
 	public ZestAssignRandomInteger deepCopy() {
 		ZestAssignRandomInteger copy = new ZestAssignRandomInteger(this.getVariableName(), this.minInt, this.maxInt);

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignRegexDelimiters.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignRegexDelimiters.java
@@ -136,9 +136,6 @@ public class ZestAssignRegexDelimiters extends ZestAssignment {
 		this.location = location;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#deepCopy()
-	 */
 	@Override
 	public ZestAssignRegexDelimiters deepCopy() {
 		ZestAssignRegexDelimiters copy = new ZestAssignRegexDelimiters(this.getIndex());
@@ -173,9 +170,6 @@ public class ZestAssignRegexDelimiters extends ZestAssignment {
 	}
 
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestAction#invoke(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public String assign(ZestResponse response, ZestRuntime runtime) throws ZestAssignFailException {
 		if (prefix == null || prefix.length() == 0) {

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignReplace.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignReplace.java
@@ -44,9 +44,6 @@ public class ZestAssignReplace extends ZestAssignment {
 		this.caseExact = caseExact;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestTransformation#transform(org.mozilla.zest.core.v1.ZestRunner, org.mozilla.zest.core.v1.ZestRequest)
-	 */
 	@Override
 	public String assign (ZestResponse response, ZestRuntime runtime) throws ZestAssignFailException {
 		String var = runtime.getVariable(getVariableName());
@@ -66,9 +63,6 @@ public class ZestAssignReplace extends ZestAssignment {
 		}
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestElement#deepCopy()
-	 */
 	@Override
 	public ZestAssignReplace deepCopy() {
 		ZestAssignReplace copy = new ZestAssignReplace(this.getVariableName(), this.replace, this.replacement, this.regex, this.caseExact);

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignString.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignString.java
@@ -38,17 +38,11 @@ public class ZestAssignString extends ZestAssignment {
 		this.string = string;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestTransformation#transform(org.mozilla.zest.core.v1.ZestRunner, org.mozilla.zest.core.v1.ZestRequest)
-	 */
 	@Override
 	public String assign (ZestResponse response, ZestRuntime runtime) {
 		return runtime.replaceVariablesInString(this.string, false);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestElement#deepCopy()
-	 */
 	@Override
 	public ZestAssignString deepCopy() {
 		ZestAssignString copy = new ZestAssignString(this.getVariableName(), this.string);

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignStringDelimiters.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignStringDelimiters.java
@@ -122,9 +122,6 @@ public class ZestAssignStringDelimiters extends ZestAssignment {
 		this.location = location;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#deepCopy()
-	 */
 	@Override
 	public ZestAssignStringDelimiters deepCopy() {
 		ZestAssignStringDelimiters copy = new ZestAssignStringDelimiters(this.getIndex());
@@ -157,9 +154,6 @@ public class ZestAssignStringDelimiters extends ZestAssignment {
 	}
 
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestAction#invoke(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public String assign(ZestResponse response, ZestRuntime runtime) throws ZestAssignFailException {
 		if (prefix == null || prefix.length() == 0) {

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignment.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignment.java
@@ -42,17 +42,11 @@ public abstract class ZestAssignment extends ZestStatement {
 		super(index);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isSameSubclass(org.mozilla.zest.core.v1.ZestElement)
-	 */
 	@Override
 	public boolean isSameSubclass(ZestElement ze) {
 		return ze instanceof ZestAssignment;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#setPrefix(java.lang.String, java.lang.String)
-	 */
 	@Override
 	void setPrefix(String oldPrefix, String newPrefix) throws MalformedURLException {
 		// Ignore
@@ -76,9 +70,6 @@ public abstract class ZestAssignment extends ZestStatement {
 		this.variableName = name;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isPassive()
-	 */
 	@Override
 	public boolean isPassive() {
 		return true;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClient.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClient.java
@@ -29,17 +29,11 @@ public abstract class ZestClient extends ZestStatement {
 
 	public abstract String invoke(ZestRuntime runtime) throws ZestClientFailException;
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isSameSubclass(org.mozilla.zest.core.v1.ZestElement)
-	 */
 	@Override
 	public boolean isSameSubclass(ZestElement ze) {
 		return ze instanceof ZestClient;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#setPrefix(java.lang.String, java.lang.String)
-	 */
 	@Override
 	void setPrefix(String oldPrefix, String newPrefix) throws MalformedURLException {
 		// Ignore

--- a/src/main/java/org/mozilla/zest/core/v1/ZestComment.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestComment.java
@@ -27,25 +27,16 @@ public class ZestComment extends ZestStatement {
 		this.comment = comment;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#setPrefix(java.lang.String, java.lang.String)
-	 */
 	@Override
 	void setPrefix(String oldPrefix, String newPrefix)
 			throws MalformedURLException {		
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#deepCopy()
-	 */
 	@Override
 	public ZestComment deepCopy() {
 		return new ZestComment(comment);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isPassive()
-	 */
 	@Override
 	public boolean isPassive() {
 		return true;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestConditional.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestConditional.java
@@ -244,9 +244,6 @@ public class ZestConditional extends ZestStatement implements ZestContainer{
 		return elseStatements;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestContainer#getIndex(org.mozilla.zest.core.v1.ZestStatement)
-	 */
 	@Override
 	public int getIndex (ZestStatement child) {
 		if (this.ifStatements.contains(child)) {
@@ -255,9 +252,6 @@ public class ZestConditional extends ZestStatement implements ZestContainer{
 		return this.elseStatements.indexOf(child);
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestContainer#move(int, org.mozilla.zest.core.v1.ZestStatement)
-	 */
 	@Override
 	public void move(int index, ZestStatement stmt) {
 		if (this.ifStatements.contains(stmt)) {
@@ -271,17 +265,11 @@ public class ZestConditional extends ZestStatement implements ZestContainer{
 		}
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isSameSubclass(org.mozilla.zest.core.v1.ZestElement)
-	 */
 	@Override
 	public boolean isSameSubclass(ZestElement ze) {
 		return ze instanceof ZestConditional;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#setPrefix(java.lang.String, java.lang.String)
-	 */
 	@Override
 	public void setPrefix(String oldPrefix, String newPrefix) throws MalformedURLException {
 		for (ZestStatement stmt : this.ifStatements) {
@@ -292,9 +280,6 @@ public class ZestConditional extends ZestStatement implements ZestContainer{
 		}
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#getTokens(java.lang.String, java.lang.String)
-	 */
 	@Override
 	public Set<String> getVariableNames() {
 		Set<String> tokens = new HashSet<String>();
@@ -318,9 +303,6 @@ public class ZestConditional extends ZestStatement implements ZestContainer{
 		return tokens;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestContainer#getLast()
-	 */
 	@Override
 	public ZestStatement getLast() {
 		if (this.elseStatements.size() > 0) {
@@ -332,9 +314,6 @@ public class ZestConditional extends ZestStatement implements ZestContainer{
 		return this;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestContainer#getChildBefore(org.mozilla.zest.core.v1.ZestStatement)
-	 */
 	@Override
 	public ZestStatement getChildBefore(ZestStatement child) {
 		if (this.ifStatements.contains(child)) {
@@ -351,9 +330,6 @@ public class ZestConditional extends ZestStatement implements ZestContainer{
 		return null;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestContainer#getStatement(int)
-	 */
 	@Override
 	public ZestStatement getStatement (int index) {
 		for (ZestStatement zr : this.getIfStatements()) {
@@ -413,9 +389,6 @@ public class ZestConditional extends ZestStatement implements ZestContainer{
 		return old_root;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#deepCopy()
-	 */
 	@Override
 	public ZestStatement deepCopy() {
 		ZestConditional copy=new ZestConditional(getIndex());
@@ -432,9 +405,6 @@ public class ZestConditional extends ZestStatement implements ZestContainer{
 		return copy;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isPassive()
-	 */
 	@Override
 	public boolean isPassive() {
 		return true;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestControl.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestControl.java
@@ -27,17 +27,11 @@ public abstract class ZestControl extends ZestStatement {
 		super(index);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isSameSubclass(org.mozilla.zest.core.v1.ZestElement)
-	 */
 	@Override
 	public boolean isSameSubclass(ZestElement ze) {
 		return ze instanceof ZestControl;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#setPrefix(java.lang.String, java.lang.String)
-	 */
 	@Override
 	void setPrefix(String oldPrefix, String newPrefix) throws MalformedURLException {
 		// Ignore

--- a/src/main/java/org/mozilla/zest/core/v1/ZestControlLoopBreak.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestControlLoopBreak.java
@@ -15,17 +15,11 @@ import java.net.MalformedURLException;
  */
 public class ZestControlLoopBreak extends ZestControl {
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#setPrefix(java.lang.String, java.lang.String)
-	 */
 	@Override
 	void setPrefix(String oldPrefix, String newPrefix)
 			throws MalformedURLException {		
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#deepCopy()
-	 */
 	@Override
 	public ZestControlLoopBreak deepCopy() {
 		ZestControlLoopBreak copy = new ZestControlLoopBreak();
@@ -33,9 +27,6 @@ public class ZestControlLoopBreak extends ZestControl {
 		return copy;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isPassive()
-	 */
 	@Override
 	public boolean isPassive() {
 		return true;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestControlLoopNext.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestControlLoopNext.java
@@ -15,17 +15,11 @@ import java.net.MalformedURLException;
  */
 public class ZestControlLoopNext extends ZestControl {
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#setPrefix(java.lang.String, java.lang.String)
-	 */
 	@Override
 	void setPrefix(String oldPrefix, String newPrefix)
 			throws MalformedURLException {
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#deepCopy()
-	 */
 	@Override
 	public ZestControlLoopNext deepCopy() {
 		ZestControlLoopNext copy = new ZestControlLoopNext();
@@ -33,9 +27,6 @@ public class ZestControlLoopNext extends ZestControl {
 		return copy;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isPassive()
-	 */
 	@Override
 	public boolean isPassive() {
 		return true;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestControlReturn.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestControlReturn.java
@@ -27,17 +27,11 @@ public class ZestControlReturn extends ZestControl {
 		this.value = value;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#setPrefix(java.lang.String, java.lang.String)
-	 */
 	@Override
 	void setPrefix(String oldPrefix, String newPrefix)
 			throws MalformedURLException {		
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#deepCopy()
-	 */
 	@Override
 	public ZestControlReturn deepCopy() {
 		ZestControlReturn copy = new ZestControlReturn(value);
@@ -45,9 +39,6 @@ public class ZestControlReturn extends ZestControl {
 		return copy;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isPassive()
-	 */
 	@Override
 	public boolean isPassive() {
 		return true;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpression.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpression.java
@@ -20,33 +20,21 @@ public abstract class ZestExpression extends ZestElement implements
 		super();
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpressionElement#isLeaf()
-	 */
 	@Override
 	public boolean isLeaf() {
 		return true;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpressionElement#isInverse()
-	 */
 	@Override
 	public boolean isInverse() {
 		return not;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpressionElement#setInverse(boolean)
-	 */
 	@Override
 	public void setInverse(boolean not) {
 		this.not = not;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpressionElement#evaluate(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public boolean evaluate(ZestRuntime runtime) {
 		boolean toReturn = isTrue(runtime);
@@ -62,9 +50,6 @@ public abstract class ZestExpression extends ZestElement implements
 	// return counter;
 	// }
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestElement#deepCopy()
-	 */
 	@Override
 	public abstract ZestExpression deepCopy();
 }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionAnd.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionAnd.java
@@ -36,9 +36,6 @@ public class ZestExpressionAnd extends ZestStructuredExpression{
 		super(andList);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpression#deepCopy()
-	 */
 	@Override
 	public ZestExpressionAnd deepCopy() {
 		List<ZestExpressionElement> copyChildren = new LinkedList<>();
@@ -51,9 +48,6 @@ public class ZestExpressionAnd extends ZestStructuredExpression{
 		return copy;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpressionElement#isTrue(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public boolean isTrue(ZestRuntime runtime) {
 		if(getChildrenCondition().isEmpty()){
@@ -69,9 +63,6 @@ public class ZestExpressionAnd extends ZestStructuredExpression{
 		return toReturn;
 	}
 	
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
 	public String toString(){
 		if(this.getChildrenCondition()== null || this.getChildrenCondition().isEmpty()){

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionClientElementExists.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionClientElementExists.java
@@ -59,9 +59,6 @@ public class ZestExpressionClientElementExists extends ZestExpression {
 		this.element = element;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpressionElement#isTrue(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public boolean isTrue (ZestRuntime runtime) {
 		WebDriver wd = runtime.getWebDriver(this.getWindowHandle());
@@ -95,9 +92,6 @@ public class ZestExpressionClientElementExists extends ZestExpression {
 		return wd.findElements(by).size() > 0;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpression#deepCopy()
-	 */
 	@Override
 	public ZestExpressionClientElementExists deepCopy() {
 		return new ZestExpressionClientElementExists(this.windowHandle, this.getType(), this.getElement());

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionEquals.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionEquals.java
@@ -51,9 +51,6 @@ public class ZestExpressionEquals extends ZestExpression{
 		this.setInverse(inverse);
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpressionElement#isTrue(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public boolean isTrue (ZestRuntime runtime) {
 		String str = runtime.getVariable(variableName);		
@@ -125,17 +122,11 @@ public class ZestExpressionEquals extends ZestExpression{
 		this.caseExact = caseExact;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpression#isLeaf()
-	 */
 	@Override
 	public boolean isLeaf() {
 		return true;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpression#deepCopy()
-	 */
 	@Override
 	public ZestExpressionEquals deepCopy() {
 		return new ZestExpressionEquals(this.getVariableName(), this.getValue(), this.isCaseExact(), this.isInverse());

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionIsInteger.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionIsInteger.java
@@ -29,9 +29,6 @@ public class ZestExpressionIsInteger extends ZestExpression{
 		this.variableName = variableName;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpressionElement#isTrue(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public boolean isTrue (ZestRuntime runtime) {
 		String str = runtime.getVariable(variableName);		
@@ -65,17 +62,11 @@ public class ZestExpressionIsInteger extends ZestExpression{
 		this.variableName = variableName;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpression#isLeaf()
-	 */
 	@Override
 	public boolean isLeaf() {
 		return true;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpression#deepCopy()
-	 */
 	@Override
 	public ZestExpressionIsInteger deepCopy() {
 		return new ZestExpressionIsInteger(this.getVariableName());

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionLength.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionLength.java
@@ -53,9 +53,6 @@ public class ZestExpressionLength extends ZestExpression {
 		this.setInverse(b);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpression#deepCopy()
-	 */
 	@Override
 	public ZestExpressionLength deepCopy() {
 		return new ZestExpressionLength(this.variableName, this.length, this.approx);
@@ -115,9 +112,6 @@ public class ZestExpressionLength extends ZestExpression {
 		this.approx = approx;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpressionElement#isTrue(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public boolean isTrue(ZestRuntime runtime) {
 		if (this.variableName == null) {
@@ -132,9 +126,6 @@ public class ZestExpressionLength extends ZestExpression {
 		return toReturn;
 	}
 	
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
 	public String toString(){
 		String expression=(isInverse()?"NOT ":"")+ "Length: "+length+" +/- "+(((double)(length*approx))/100);

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionOr.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionOr.java
@@ -30,13 +30,6 @@ public class ZestExpressionOr extends ZestStructuredExpression {
 		super(children);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see
-	 * org.mozilla.zest.core.v1.ZestExpressionElement#isTrue(org.mozilla.zest
-	 * .core.v1.ZestResponse)
-	 */
 	@Override
 	public boolean isTrue(ZestRuntime runtime) {
 		boolean toReturn = false;
@@ -50,11 +43,6 @@ public class ZestExpressionOr extends ZestStructuredExpression {
 		return toReturn;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see org.mozilla.zest.core.v1.ZestExpression#deepCopy()
-	 */
 	@Override
 	public ZestExpressionOr deepCopy() {
 		List<ZestExpressionElement> copyChildren = new LinkedList<>();
@@ -67,9 +55,6 @@ public class ZestExpressionOr extends ZestStructuredExpression {
 		return copy;
 	}
 
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
 	public String toString() {
 		if(this.getChildrenCondition()==null || this.getChildrenCondition().isEmpty()){

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionRegex.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionRegex.java
@@ -64,9 +64,6 @@ public class ZestExpressionRegex extends ZestExpression{
 		}
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpressionElement#isTrue(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public boolean isTrue (ZestRuntime runtime) {
 		String str = runtime.getVariable(variableName);		
@@ -140,25 +137,16 @@ public class ZestExpressionRegex extends ZestExpression{
 		this.caseExact = caseExact;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpression#isLeaf()
-	 */
 	@Override
 	public boolean isLeaf() {
 		return true;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpression#deepCopy()
-	 */
 	@Override
 	public ZestExpressionRegex deepCopy() {
 		return new ZestExpressionRegex(this.getVariableName(), this.getRegex(), this.isCaseExact(), this.isInverse());
 	}
 	
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
 	public String toString(){
 		String expression=(isInverse()?"NOT ":"")+"REGEX: "+regex;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionResponseTime.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionResponseTime.java
@@ -34,9 +34,6 @@ public class ZestExpressionResponseTime extends ZestExpression {
 		this.timeInMs=time;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpressionElement#isTrue(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public boolean isTrue (ZestRuntime runtime) {
 		ZestResponse response = runtime.getLastResponse();
@@ -86,9 +83,6 @@ public class ZestExpressionResponseTime extends ZestExpression {
 		this.timeInMs = timeInMs;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpression#deepCopy()
-	 */
 	@Override
 	public ZestExpressionResponseTime deepCopy() {
 		ZestExpressionResponseTime copy = new ZestExpressionResponseTime();
@@ -97,9 +91,6 @@ public class ZestExpressionResponseTime extends ZestExpression {
 		return copy;
 	}
 	
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
 	public String toString(){
 		String expression=(isInverse()?"NOT ":"")+"Response Time "+(isGreaterThan()?"> ":"< ")+timeInMs;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionStatusCode.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionStatusCode.java
@@ -31,9 +31,6 @@ public class ZestExpressionStatusCode extends ZestExpression {
 		this.code=code;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpressionElement#isTrue(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public boolean isTrue (ZestRuntime runtime) {
 		ZestResponse response = runtime.getLastResponse();
@@ -61,9 +58,6 @@ public class ZestExpressionStatusCode extends ZestExpression {
 		this.code = code;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpression#deepCopy()
-	 */
 	@Override
 	public ZestExpressionStatusCode deepCopy() {
 		ZestExpressionStatusCode copy = new ZestExpressionStatusCode();
@@ -71,9 +65,6 @@ public class ZestExpressionStatusCode extends ZestExpression {
 		return copy;
 	}
 	
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
 	public String toString(){
 		String expression=(isInverse()?"NOT ":"")+"Status Code: "+code;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionURL.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionURL.java
@@ -44,9 +44,6 @@ public class ZestExpressionURL extends ZestExpression {
 		this.setExcludeRegexes(excludeRegexes);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpressionElement#isTrue(org.mozilla.zest.core.v1.ZestResponse)
-	 */
 	@Override
 	public boolean isTrue(ZestRuntime runtime) {
 		ZestRequest req = runtime.getLastRequest();
@@ -136,9 +133,6 @@ public class ZestExpressionURL extends ZestExpression {
 		this.excludePatterns = null;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpression#deepCopy()
-	 */
 	@Override
 	public ZestExpressionURL deepCopy() {
 		ZestExpressionURL copy = new ZestExpressionURL();
@@ -149,9 +143,6 @@ public class ZestExpressionURL extends ZestExpression {
 		return copy;
 	}
 	
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
 	public String toString(){
 		String expression=(isInverse()?"NOT ":"")+"URL: ACCEPT:";

--- a/src/main/java/org/mozilla/zest/core/v1/ZestFieldDefinition.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestFieldDefinition.java
@@ -53,9 +53,6 @@ public class ZestFieldDefinition extends ZestElement {
 		this.fieldName = fieldName;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestElement#deepCopy()
-	 */
 	@Override
 	public ZestFieldDefinition deepCopy() {
 		ZestFieldDefinition ze = new ZestFieldDefinition(this.formName, this.fieldName);

--- a/src/main/java/org/mozilla/zest/core/v1/ZestHttpAuthentication.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestHttpAuthentication.java
@@ -46,9 +46,6 @@ public class ZestHttpAuthentication extends ZestAuthentication {
 		this.password = password;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestElement#deepCopy()
-	 */
 	@Override
 	public ZestHttpAuthentication deepCopy() {
 		return new ZestHttpAuthentication(this.site, this.realm, this.username, this.password);

--- a/src/main/java/org/mozilla/zest/core/v1/ZestJSON.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestJSON.java
@@ -74,9 +74,6 @@ public class ZestJSON implements JsonDeserializer<ZestElement>, JsonSerializer<Z
 		return gson;
 	}
 
-	/* (non-Javadoc)
-	 * @see com.google.gson.JsonDeserializer#deserialize(com.google.gson.JsonElement, java.lang.reflect.Type, com.google.gson.JsonDeserializationContext)
-	 */
 	@Override
 	public ZestElement deserialize(JsonElement element, Type rawType,
 			JsonDeserializationContext arg2) throws JsonParseException {
@@ -97,9 +94,6 @@ public class ZestJSON implements JsonDeserializer<ZestElement>, JsonSerializer<Z
 		return null;
 	}
 
-	/* (non-Javadoc)
-	 * @see com.google.gson.JsonSerializer#serialize(java.lang.Object, java.lang.reflect.Type, com.google.gson.JsonSerializationContext)
-	 */
 	@Override
 	public JsonElement serialize(ZestElement element, Type rawType,
 			JsonSerializationContext context) {

--- a/src/main/java/org/mozilla/zest/core/v1/ZestRequest.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestRequest.java
@@ -61,9 +61,6 @@ public class ZestRequest extends ZestStatement {
 		super();
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#deepCopy()
-	 */
 	@Override
 	public ZestRequest deepCopy () {
 		ZestRequest zr = new ZestRequest(this.getIndex());
@@ -305,17 +302,11 @@ public class ZestRequest extends ZestStatement {
 		this.setData(tokens.replaceInString(this.getData(), false));
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isSameSubclass(org.mozilla.zest.core.v1.ZestElement)
-	 */
 	@Override
 	public boolean isSameSubclass(ZestElement ze) {
 		return ze instanceof ZestRequest;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#setPrefix(java.lang.String, java.lang.String)
-	 */
 	@Override
 	public void setPrefix(String oldPrefix, String newPrefix) throws MalformedURLException {
 		if (this.getUrl() != null && this.getUrl().toString().startsWith(oldPrefix)) {
@@ -326,9 +317,6 @@ public class ZestRequest extends ZestStatement {
 		}
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isPassive()
-	 */
 	@Override
 	public boolean isPassive() {
 		return false;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestResponse.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestResponse.java
@@ -43,9 +43,6 @@ public class ZestResponse extends ZestElement {
 		this.responseTimeInMs = responseTimeInMs;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestElement#deepCopy()
-	 */
 	@Override
 	public ZestResponse deepCopy() {
 		ZestResponse zr = new ZestResponse(this.url, this.headers, this.body, this.statusCode, this.responseTimeInMs);

--- a/src/main/java/org/mozilla/zest/core/v1/ZestScript.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestScript.java
@@ -139,9 +139,6 @@ public class ZestScript extends ZestStatement implements ZestContainer {
 		return type;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#deepCopy()
-	 */
 	@Override
 	public ZestScript deepCopy() {
 		ZestScript script = new ZestScript();
@@ -206,9 +203,6 @@ public class ZestScript extends ZestStatement implements ZestContainer {
 		checkStatementIndexes();
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestContainer#move(int, org.mozilla.zest.core.v1.ZestStatement)
-	 */
 	@Override
 	public void move(int index, ZestStatement req) {
 		this.remove(req);
@@ -237,9 +231,6 @@ public class ZestScript extends ZestStatement implements ZestContainer {
 		checkStatementIndexes();
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestContainer#getStatement(int)
-	 */
 	@Override
 	public ZestStatement getStatement (int index) {
 		checkStatementIndexes();
@@ -372,9 +363,6 @@ public class ZestScript extends ZestStatement implements ZestContainer {
 		this.setPrefix(this.prefix, newPrefix);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#setPrefix(java.lang.String, java.lang.String)
-	 */
 	@Override
 	public void setPrefix(String oldPrefix, String newPrefix) throws MalformedURLException {
 		if (newPrefix != null && newPrefix.length() > 0) {
@@ -478,9 +466,6 @@ public class ZestScript extends ZestStatement implements ZestContainer {
 		this.author = author;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#getTokens(java.lang.String, java.lang.String)
-	 */
 	@Override
 	public Set<String> getVariableNames() {
 		Set<String> tokens = new HashSet<String>();
@@ -534,25 +519,16 @@ public class ZestScript extends ZestStatement implements ZestContainer {
 		return ids;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestContainer#getIndex(org.mozilla.zest.core.v1.ZestStatement)
-	 */
 	@Override
 	public int getIndex (ZestStatement child) {
 		return this.statements.indexOf(child);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestContainer#getLast()
-	 */
 	@Override
 	public ZestStatement getLast() {
 		return null;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestContainer#getChildBefore(org.mozilla.zest.core.v1.ZestStatement)
-	 */
 	@Override
 	public ZestStatement getChildBefore(ZestStatement child) {
 		if (this.statements.contains(child)) {
@@ -564,9 +540,6 @@ public class ZestScript extends ZestStatement implements ZestContainer {
 		return null;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestStatement#isPassive()
-	 */
 	@Override
 	public boolean isPassive() {
 		return Type.Passive.equals(this.getType());

--- a/src/main/java/org/mozilla/zest/core/v1/ZestStatement.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestStatement.java
@@ -41,9 +41,6 @@ public abstract class ZestStatement extends ZestElement {
 	public ZestStatement() {
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestElement#isSameSubclass(org.mozilla.zest.core.v1.ZestElement)
-	 */
 	@Override
 	public boolean isSameSubclass(ZestElement ze) {
 		return ze instanceof ZestStatement;
@@ -162,9 +159,6 @@ public abstract class ZestStatement extends ZestElement {
 	 */
 	abstract void setPrefix(String oldPrefix, String newPrefix) throws MalformedURLException;
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestElement#deepCopy()
-	 */
 	@Override
 	public abstract ZestStatement deepCopy();
 	

--- a/src/main/java/org/mozilla/zest/core/v1/ZestStructuredExpression.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestStructuredExpression.java
@@ -61,9 +61,6 @@ public abstract class ZestStructuredExpression extends ZestExpression implements
 		return this.children;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestExpression#isLeaf()
-	 */
 	@Override
 	public boolean isLeaf() {
 		return false;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestVariables.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestVariables.java
@@ -54,9 +54,6 @@ public class ZestVariables extends ZestElement {
 		super();
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mozilla.zest.core.v1.ZestElement#deepCopy()
-	 */
 	@Override
 	public ZestVariables deepCopy() {
 		ZestVariables zt = new ZestVariables();


### PR DESCRIPTION
Remove all "(non-Javadoc)" comments, not necessary (overridden methods
are already annotated).