### PR TITLE
Add LICENSE and normalise license header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+
+jdk:
+  - oraclejdk8

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "com.diffplug.gradle.spotless" version "3.2.0"
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = '3.2.1'
 }
@@ -50,6 +54,12 @@ tasks.withType(Javadoc) {
     }
     if (JavaVersion.current().isJava8Compatible()) {
         options.addStringOption('Xdoclint:none', '-quiet')
+    }
+}
+
+spotless {
+    java {
+        licenseHeaderFile "$projectDir/gradle/spotless/license.java"
     }
 }
 

--- a/gradle/spotless/license.java
+++ b/gradle/spotless/license.java
@@ -1,0 +1,3 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAction.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAction.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionFail.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionFail.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionFailException.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionFailException.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionIntercept.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionIntercept.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionInvoke.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionInvoke.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.io.BufferedReader;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionPrint.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionPrint.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionScan.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionScan.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionSleep.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionSleep.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssertFailException.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssertFailException.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssertion.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssertion.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignCalc.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignCalc.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignFailException.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignFailException.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignFieldValue.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignFieldValue.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.util.List;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignRandomInteger.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignRandomInteger.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.security.SecureRandom;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignRegexDelimiters.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignRegexDelimiters.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.util.Arrays;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignReplace.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignReplace.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignString.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignString.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignStringDelimiters.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignStringDelimiters.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.util.Arrays;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignment.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignment.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAuthentication.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAuthentication.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClient.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClient.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientFailException.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientFailException.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestComment.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestComment.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestConditional.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestConditional.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestContainer.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestContainer.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.util.List;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestControl.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestControl.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestControlLoopBreak.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestControlLoopBreak.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestControlLoopNext.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestControlLoopNext.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestControlReturn.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestControlReturn.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestElement.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestElement.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.security.InvalidParameterException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionClientElementExists.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionClientElementExists.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import org.openqa.selenium.By;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionEquals.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionEquals.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionIsInteger.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionIsInteger.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionLength.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionLength.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionRegex.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionRegex.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.util.regex.Pattern;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionResponseTime.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionResponseTime.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionStatusCode.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionStatusCode.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionURL.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionURL.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.util.ArrayList;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestFieldDefinition.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestFieldDefinition.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestHttpAuthentication.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestHttpAuthentication.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestInvalidCommonTestException.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestInvalidCommonTestException.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestJSON.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestJSON.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.lang.reflect.Type;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoop.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoop.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopClientElements.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopClientElements.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.io.FileNotFoundException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopFile.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopFile.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.io.File;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopInteger.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopInteger.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.LinkedList;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopRegex.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopRegex.java
@@ -1,8 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopState.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopState.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateClientElements.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateClientElements.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateFile.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateFile.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateInteger.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateInteger.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateRegex.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateRegex.java
@@ -1,8 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateString.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateString.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopString.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopString.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.LinkedList;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenClientElementsSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenClientElementsSet.java
@@ -1,8 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.Collections;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenFileSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenFileSet.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.io.File;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenIntegerSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenIntegerSet.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenRegexSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenRegexSet.java
@@ -1,8 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.io.FileNotFoundException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenSet.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenStringSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenStringSet.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.LinkedList;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestRequest.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestRequest.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestResponse.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestResponse.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.net.URL;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestRunner.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestRunner.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.io.IOException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestRuntime.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestRuntime.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.util.List;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestScript.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestScript.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestStatement.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestStatement.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestVariables.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestVariables.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.core.v1;
 
 import java.io.UnsupportedEncodingException;

--- a/src/main/java/org/mozilla/zest/impl/CmdLine.java
+++ b/src/main/java/org/mozilla/zest/impl/CmdLine.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.impl;
 
 import java.io.BufferedReader;

--- a/src/main/java/org/mozilla/zest/impl/ZestBasicRunner.java
+++ b/src/main/java/org/mozilla/zest/impl/ZestBasicRunner.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.impl;
 
 import java.io.BufferedReader;

--- a/src/main/java/org/mozilla/zest/impl/ZestPrinter.java
+++ b/src/main/java/org/mozilla/zest/impl/ZestPrinter.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.impl;
 
 import org.mozilla.zest.core.v1.ZestAction;

--- a/src/main/java/org/mozilla/zest/impl/ZestUtils.java
+++ b/src/main/java/org/mozilla/zest/impl/ZestUtils.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.impl;
 
 import java.util.ArrayList;

--- a/src/test/java/org/mozilla/zest/test/v1/TestPrint.java
+++ b/src/test/java/org/mozilla/zest/test/v1/TestPrint.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import java.io.FileNotFoundException;

--- a/src/test/java/org/mozilla/zest/test/v1/TestRuntime.java
+++ b/src/test/java/org/mozilla/zest/test/v1/TestRuntime.java
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import java.util.List;

--- a/src/test/java/org/mozilla/zest/test/v1/TestSerializationScriptWithLoop.java
+++ b/src/test/java/org/mozilla/zest/test/v1/TestSerializationScriptWithLoop.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import java.io.FileNotFoundException;

--- a/src/test/java/org/mozilla/zest/test/v1/TestZestScriptWithLoop.java
+++ b/src/test/java/org/mozilla/zest/test/v1/TestZestScriptWithLoop.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import java.io.IOException;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestActionInvokeUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestActionInvokeUnitTest.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestActionSleepUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestActionSleepUnitTest.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssertBodyRegexUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssertBodyRegexUnitTest.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignRegexDelimitersUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignRegexDelimitersUnitTest.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignReplaceUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignReplaceUnitTest.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignStringDelimitersUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignStringDelimitersUnitTest.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignStringUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignStringUnitTest.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestClientLaunchUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestClientLaunchUnitTest.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexComplexUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexComplexUnitTest.java
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import org.junit.Test;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexExprUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexExprUnitTest.java
@@ -1,11 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
-
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexUnitTest.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionAndUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionAndUnitTest.java
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionIsIntegerUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionIsIntegerUnitTest.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionLengthUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionLengthUnitTest.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionRegexUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionRegexUnitTest.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionResponseTimeUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionResponseTimeUnitTest.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionURLUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionURLUnitTest.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopClientElementUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopClientElementUnitTest.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopFileUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopFileUnitTest.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import java.io.File;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopIntegerUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopIntegerUnitTest.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopSerializationUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopSerializationUnitTest.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopStateUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopStateUnitTest.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopStringUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopStringUnitTest.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopTokenSetUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopTokenSetUnitTest.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestRequestUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestRequestUnitTest.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestScriptUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestScriptUnitTest.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestStructuredExpressionUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestStructuredExpressionUnitTest.java
@@ -1,10 +1,6 @@
-/**
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
- * @author Alessandro Secco: seccoale@gmail.com
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestVariableUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestVariableUnitTest.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestVariablesUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestVariablesUnitTest.java
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
Add a top level LICENSE file with MPL2.
Add Spotless Gradle plugin and the license header for Java source files,
to ensure all Java source files have the expected license header (the
files were updated accordingly).
Update Travis CI build configuration file to use JDK 8 (required by
Spotless plugin).