### PR TITLE
Enable lint compiler flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,14 @@ jar {
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
+    options.compilerArgs = [
+        // Enable all warnings,
+        '-Xlint:all',
+        // but allow to compile with newer Java versions.
+        '-Xlint:-options',
+        // Be strict, treat warnings as errors.
+        '-Werror'
+    ]
 }
 
 tasks.withType(Javadoc) {

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssertion.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssertion.java
@@ -69,7 +69,6 @@ public class ZestAssertion extends ZestElement{
 
 	@Override
 	public ZestElement deepCopy() {
-		ZestExpressionElement copy_root_expr=(ZestExpressionElement)rootExpression.deepCopy();
-		return new ZestAssertion(copy_root_expr);
+		return new ZestAssertion(rootExpression.deepCopy());
 	}
 }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestConditional.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestConditional.java
@@ -392,7 +392,7 @@ public class ZestConditional extends ZestStatement implements ZestContainer{
 	public ZestStatement deepCopy() {
 		ZestConditional copy=new ZestConditional(getIndex());
 		if(this.rootExpression!=null){
-			copy.rootExpression=(ZestExpressionElement)rootExpression.deepCopy();
+			copy.rootExpression=rootExpression.deepCopy();
 		}
 		for(ZestStatement stmt:ifStatements){
 			copy.ifStatements.add(stmt.deepCopy());

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopState.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopState.java
@@ -127,12 +127,36 @@ public abstract class ZestLoopState<T> extends ZestElement {
 	}
 
 	@Override
-	public boolean equals(Object otherObject) {
-		if (otherObject instanceof ZestLoopState<?>) {
-			ZestLoopState<?> otherState = (ZestLoopState<?>) otherObject;
-			return this.currentIndex == otherState.currentIndex
-					&& this.currentToken.equals(otherState.currentToken);
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + currentIndex;
+		result = prime * result + ((currentToken == null) ? 0 : currentToken.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
 		}
-		return false;
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		ZestLoopState<?> other = (ZestLoopState<?>) obj;
+		if (currentIndex != other.currentIndex) {
+			return false;
+		}
+		if (currentToken == null) {
+			if (other.currentToken != null) {
+				return false;
+			}
+		} else if (!currentToken.equals(other.currentToken)) {
+			return false;
+		}
+		return true;
 	}
 }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateInteger.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateInteger.java
@@ -45,13 +45,4 @@ public class ZestLoopStateInteger extends ZestLoopState<Integer> {
 		return copy;
 	}
 
-	@Override
-	public boolean equals(Object otherObject) {
-		if (otherObject instanceof ZestLoopStateInteger) {
-			ZestLoopStateInteger otherState = (ZestLoopStateInteger) otherObject;
-			return super.equals(otherState);
-		}
-		return false;
-	}
-
 }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenIntegerSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenIntegerSet.java
@@ -97,14 +97,38 @@ public class ZestLoopTokenIntegerSet extends ZestElement implements
 		return end-start;
 	}
 	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + end;
+		result = prime * result + start;
+		result = prime * result + step;
+		return result;
+	}
 
 	@Override
-	public boolean equals(Object otherObject){
-		if(otherObject instanceof ZestLoopTokenIntegerSet){
-			ZestLoopTokenIntegerSet otherSet=(ZestLoopTokenIntegerSet) otherObject;
-			return this.start==otherSet.start && this.end==otherSet.end && this.step==otherSet.step;
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
 		}
-		return false;
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		ZestLoopTokenIntegerSet other = (ZestLoopTokenIntegerSet) obj;
+		if (end != other.end) {
+			return false;
+		}
+		if (start != other.start) {
+			return false;
+		}
+		if (step != other.step) {
+			return false;
+		}
+		return true;
 	}
 
 	@Override

--- a/src/main/java/org/mozilla/zest/impl/ZestPrinter.java
+++ b/src/main/java/org/mozilla/zest/impl/ZestPrinter.java
@@ -186,7 +186,7 @@ public class ZestPrinter {
 			if (stmt instanceof ZestLoopString) {
 				ZestLoopString loopString = (ZestLoopString) loop;
 				System.out.print("FOR tokens IN [");
-				ZestLoopTokenStringSet set = (ZestLoopTokenStringSet) loopString.getSet();
+				ZestLoopTokenStringSet set = loopString.getSet();
 				for (int i = 0; i < set.size() - 1; i++) {
 					System.out.print(set.getToken(i) + ",");
 				}

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopStringUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopStringUnitTest.java
@@ -66,8 +66,7 @@ public class ZestLoopStringUnitTest {
 		for (int i = 0; i < stopIndex; i++) {
 			loop.loop();
 		}
-		ZestLoopStateString state = (ZestLoopStateString) loop
-				.getCurrentState();
+		ZestLoopStateString state = loop.getCurrentState();
 		boolean rightIndex = state.getCurrentIndex() == stopIndex;
 		boolean rightValue = state.getCurrentToken().equals(
 				values[state.getCurrentIndex()]);
@@ -107,7 +106,7 @@ public class ZestLoopStringUnitTest {
 		loop.addStatement(new ZestConditional());
 		loop.addStatement(new ZestLoopString(values));
 		loop.addStatement(new ZestActionFail());
-		ZestLoopString copy = (ZestLoopString) loop.deepCopy();
+		ZestLoopString copy = loop.deepCopy();
 		assertTrue("same state",
 				copy.getCurrentState().equals(loop.getCurrentState()));
 	}


### PR DESCRIPTION
Enable all warnings (except "options" warnings, to allow to compile with
newer Java versions), also, treat warnings as errors (strict).
Address the warnings:
 - Remove unnecessary casts;
 - Add hashCode and tweak equals where needed (check if it's the same
 instance and class then equals the fields properly checking for nulls);
 - Remove unnecessary equals methods (i.e. use base class).