### PR TITLE
Use StringBuilder for string loop concatenations

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionAnd.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionAnd.java
@@ -68,11 +68,16 @@ public class ZestExpressionAnd extends ZestStructuredExpression{
 		if(this.getChildrenCondition()== null || this.getChildrenCondition().isEmpty()){
 			return "Empty AND";
 		}
-		String expression=(isInverse()?"NOT (":"(");
-		for(int i=0; i<this.getChildrenCondition().size()-1; i++){
-			expression += " "+this.getChild(i).toString()+" AND";
+		StringBuilder expression = new StringBuilder(150);
+		if (isInverse()) {
+			expression.append("NOT ");
 		}
-		expression+=this.getChild(this.getChildrenCondition().size()-1).toString()+")";
-		return expression;
+		expression.append('(');
+		int i = 0;
+		for (; i < this.getChildrenCondition().size() - 1; i++) {
+			expression.append(this.getChild(i).toString()).append(" AND ");
+		}
+		expression.append(this.getChild(i).toString()).append(')');
+		return expression.toString();
 	}
 }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionOr.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionOr.java
@@ -60,12 +60,16 @@ public class ZestExpressionOr extends ZestStructuredExpression {
 		if(this.getChildrenCondition()==null || this.getChildrenCondition().isEmpty()){
 			return "Empty OR";
 		}
-		String expression = (isInverse() ? "NOT (" : "(");
-		for (int i = 0; i < this.getChildrenCondition().size() - 1; i++) {
-			expression += " " + this.getChild(i).toString() + " OR";
+		StringBuilder expression = new StringBuilder(150);
+		if (isInverse()) {
+			expression.append("NOT ");
 		}
-		expression += this.getChild(this.getChildrenCondition().size() - 1)
-				.toString() + ")";
-		return expression;
+		expression.append('(');
+		int i = 0;
+		for (; i < this.getChildrenCondition().size() - 1; i++) {
+			expression.append(this.getChild(i).toString()).append(" OR ");
+		}
+		expression.append(this.getChild(i).toString()).append(')');
+		return expression.toString();
 	}
 }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionURL.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionURL.java
@@ -144,14 +144,18 @@ public class ZestExpressionURL extends ZestExpression {
 	
 	@Override
 	public String toString(){
-		String expression=(isInverse()?"NOT ":"")+"URL: ACCEPT:";
+		StringBuilder expression = new StringBuilder(150);
+		if (isInverse()) {
+			expression.append("NOT ");
+		}
+		expression.append("URL: ACCEPT:");
 		for(String s:includeRegexes){
-			expression+=" "+s;
+			expression.append(' ').append(s);
 		}
-		expression+=", EXCLUDE:";
+		expression.append(", EXCLUDE:");
 		for(String s:excludeRegexes){
-			expression+=s+" ";
+			expression.append(' ').append(s);
 		}
-		return expression;
+		return expression.toString();
 	}
 }


### PR DESCRIPTION
Change toString() methods to use a StringBuilder, when the strings were
being concatenated in loops.