### PR TITLE
Implement exact case replacement when assigning

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignReplace.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignReplace.java
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
+import java.util.regex.Pattern;
+
 /**
  * The Class ZestAssignString assigns a string (which can include other variables) to the specified variable.
  */
@@ -50,16 +52,15 @@ public class ZestAssignReplace extends ZestAssignment {
 			return null;
 		}
 		String orig = runtime.replaceVariablesInString(var, false);
-		// TODO handle caseExact/ignore
-		if (regex) {
-			try {
-				return orig.replaceAll(replace, replacement);
-			} catch (Exception e) {
-				throw new ZestAssignFailException (this, e.getMessage());
-			}
-		} else {
-			return orig.replace(this.replace, this.replacement);
+		try {
+			return createPattern().matcher(orig).replaceAll(replacement);
+		} catch (Exception e) {
+			throw new ZestAssignFailException (this, e.getMessage());
 		}
+	}
+
+	private Pattern createPattern() {
+		return Pattern.compile(regex ? replace : Pattern.quote(replace), caseExact ? 0 : Pattern.CASE_INSENSITIVE);
 	}
 
 	@Override

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignReplaceUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignReplaceUnitTest.java
@@ -62,4 +62,61 @@ public class ZestAssignReplaceUnitTest {
 		assertEquals(assign.isRegex(), assign2.isRegex());
 	}
 
+	@Test
+	public void shouldReplaceStringWithDifferentCaseWhenUsingPlainStringReplacementWithoutExactCase() throws Exception {
+		// Given
+		boolean regex = false;
+		boolean exactCase = false;
+		String varName = "VarName";
+		ZestAssignReplace assign = new ZestAssignReplace(varName, "XyZ", "123", regex, exactCase);
+		// When
+		String assignment = assign.assign(null, createRuntime(varName, "Xyz xyz"));
+		// Then
+		assertEquals(assignment, "123 123");
+	}
+
+	@Test
+	public void shouldReplaceStringWithDifferentCaseWhenUsingRegexReplacementWithoutExactCase() throws Exception {
+		// Given
+		boolean regex = true;
+		boolean exactCase = false;
+		String varName = "VarName";
+		ZestAssignReplace assign = new ZestAssignReplace(varName, "Xy[Z]", "123", regex, exactCase);
+		// When
+		String assignment = assign.assign(null, createRuntime(varName, "Xyz xyz"));
+		// Then
+		assertEquals(assignment, "123 123");
+	}
+
+	@Test
+	public void shouldReplaceStringWithExactCaseWhenUsingPlainStringReplacementWithExactCase() throws Exception {
+		// Given
+		boolean regex = false;
+		boolean exactCase = true;
+		String varName = "VarName";
+		ZestAssignReplace assign = new ZestAssignReplace(varName, "Xyz", "123", regex, exactCase);
+		// When
+		String assignment = assign.assign(null, createRuntime(varName, "Xyz xyz"));
+		// Then
+		assertEquals(assignment, "123 xyz");
+	}
+
+	@Test
+	public void shouldReplaceStringWithExactCaseWhenUsingRegexReplacementWithExactCase() throws Exception {
+		// Given
+		boolean regex = true;
+		boolean exactCase = true;
+		String varName = "VarName";
+		ZestAssignReplace assign = new ZestAssignReplace(varName, "Xy[z]", "123", regex, exactCase);
+		// When
+		String assignment = assign.assign(null, createRuntime(varName, "Xyz xyz"));
+		// Then
+		assertEquals(assignment, "123 xyz");
+	}
+
+	private static TestRuntime createRuntime(String varName, String varValue) {
+		TestRuntime runtime = new TestRuntime();
+		runtime.setVariable(varName, varValue);
+		return runtime;
+	}
 }


### PR DESCRIPTION
Change ZestAssignReplace to implement the exact case replacement, for
plain and regular expression strings.
Add tests to assert the expected behaviour.