### PR TITLE
Correct script Type equality checks

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestScript.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestScript.java
@@ -541,7 +541,7 @@ public class ZestScript extends ZestStatement implements ZestContainer {
 	
 	@Override
 	public boolean isPassive() {
-		return Type.Passive.equals(this.getType());
+		return this.getType() != null && Type.Passive.equals(Type.valueOf(this.getType()));
 	}
 
 	private void checkStatementIndexes() {

--- a/src/main/java/org/mozilla/zest/impl/ZestBasicRunner.java
+++ b/src/main/java/org/mozilla/zest/impl/ZestBasicRunner.java
@@ -157,7 +157,7 @@ public class ZestBasicRunner implements ZestRunner, ZestRuntime {
 		if (skipStatements || ! stmt.isEnabled()) {
 			return lastRes;
 		}
-		if (ZestScript.Type.Passive.equals(script.getType())
+		if (script.getType() != null && ZestScript.Type.Passive.equals(ZestScript.Type.valueOf(script.getType()))
 				&& !stmt.isPassive()) {
 			throw new IllegalArgumentException(stmt.getElementType()
 					+ " not allowed in passive scripts");


### PR DESCRIPTION
Change ZestBasicRunner and ZestScript to convert the type name (String)
to the corresponding Type before checking if the type is the same
(otherwise it would always evaluate to false).