### PR TITLE
Fix NullPointerExceptions in ZestExpressionRegex

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionRegex.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionRegex.java
@@ -66,10 +66,10 @@ public class ZestExpressionRegex extends ZestExpression{
 	@Override
 	public boolean isTrue (ZestRuntime runtime) {
 		String str = runtime.getVariable(variableName);		
-		if (str == null) {
+		if (str == null || regex == null) {
 			return false;
 		}
-		if (pattern == null && regex != null) {
+		if (pattern == null) {
 			if (caseExact) {
 				this.pattern = Pattern.compile(regex);
 			} else {
@@ -114,7 +114,7 @@ public class ZestExpressionRegex extends ZestExpression{
 	 */
 	public void setRegex(String regex) {
 		this.regex = regex;
-		this.pattern = Pattern.compile(regex);
+		this.pattern = regex != null ? Pattern.compile(regex) : null;
 	}
 
 

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionRegexUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionRegexUnitTest.java
@@ -6,6 +6,8 @@ package org.mozilla.zest.test.v1;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+
 import org.junit.Test;
 import org.mozilla.zest.core.v1.ZestExpressionRegex;
 import org.mozilla.zest.core.v1.ZestResponse;
@@ -95,5 +97,50 @@ public class ZestExpressionRegexUnitTest {
 		ZestResponse response = new ZestResponse(null, null, null, 0, 0);
 		ZestExpressionRegex regex = new ZestExpressionRegex(ZestVariables.RESPONSE_HEADER, "");
 		assertFalse(regex.isTrue(new TestRuntime(response)));
+	}
+
+	@Test
+	public void shouldEvaluateAlwaysToFalseWithNullRegex() {
+		// Given
+		String nullRegex = null;
+		String varName = "VarName";
+		ZestExpressionRegex expressionRegex = new ZestExpressionRegex(varName, nullRegex);
+		for (String varValue : Arrays.asList("", "Some value", "A\nB", "$", ".")) {
+			// When
+			boolean evalution = expressionRegex.evaluate(createRuntime(varName, varValue));
+			// Then
+			assertFalse("String \"" + varValue + "\" evaludated to false.", evalution);
+		}
+	}
+
+	@Test
+	public void shouldEvaluateAlwaysToTrueWithEmptyRegex() {
+		// Given
+		String emptyRegex = "";
+		String varName = "VarName";
+		ZestExpressionRegex expressionRegex = new ZestExpressionRegex(varName, emptyRegex);
+		for (String varValue : Arrays.asList("", "Some value", "A\nB", "$", ".")) {
+			// When
+			boolean evalution = expressionRegex.evaluate(createRuntime(varName, varValue));
+			// Then
+			assertTrue("String \"" + varValue + "\" evaludated to false.", evalution);
+		}
+	}
+
+	@Test
+	public void shouldAllowToSetNullRegex() {
+		// Given
+		String nullRegex = null;
+		ZestExpressionRegex regex = new ZestExpressionRegex("VarName", "");
+		// When
+		regex.setRegex(nullRegex);
+		// Then
+		assertTrue(regex.getRegex() == null);
+	}
+
+	private static TestRuntime createRuntime(String varName, String varValue) {
+		TestRuntime runtime = new TestRuntime();
+		runtime.setVariable(varName, varValue);
+		return runtime;
 	}
 }


### PR DESCRIPTION
Change ZestExpressionRegex to properly handle the null regular
expression when setting it and when evaluating the expression.
Add tests to assert the expected behaviour.