### PR TITLE
Fix NullPointerException in ZestAssignRegexDelimiters after json deserialization

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignRegexDelimiters.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignRegexDelimiters.java
@@ -88,9 +88,7 @@ public class ZestAssignRegexDelimiters extends ZestAssignment {
 	 */
 	public void setPrefix(String prefix) {
 		this.prefix = prefix;
-		if (prefix != null) {
-			this.prefixPattern = Pattern.compile(prefix);
-		}
+		this.prefixPattern = null;
 	}
 
 	/**
@@ -109,9 +107,7 @@ public class ZestAssignRegexDelimiters extends ZestAssignment {
 	 */
 	public void setPostfix(String postfix) {
 		this.postfix = postfix;
-		if (postfix != null) {
-			this.postfixPattern = Pattern.compile(postfix);
-		}
+		this.postfixPattern = null;
 	}
 
 	/**
@@ -154,6 +150,8 @@ public class ZestAssignRegexDelimiters extends ZestAssignment {
 	 */
 	private String getTokenValue(String str) {
 		if (str != null) {
+			checkPatterns();
+			
 			Matcher prefixMatcher = this.prefixPattern.matcher(str);
 			if (prefixMatcher.find()) {
 				int tokenStart = prefixMatcher.end();
@@ -166,6 +164,19 @@ public class ZestAssignRegexDelimiters extends ZestAssignment {
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Check if the pattern are set.
+     * They will not be set after a json deserialisation using field reflexion.
+     */
+	private void checkPatterns() {		
+		if (prefixPattern==null) {
+			prefixPattern = Pattern.compile(prefix);
+		}
+		if (postfixPattern==null) {
+			postfixPattern = Pattern.compile(postfix);
+		}
 	}
 
 	

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignRegexDelimitersUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignRegexDelimitersUnitTest.java
@@ -6,10 +6,18 @@ package org.mozilla.zest.test.v1;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.mozilla.zest.core.v1.ZestAssignFailException;
 import org.mozilla.zest.core.v1.ZestAssignRegexDelimiters;
+import org.mozilla.zest.core.v1.ZestJSON;
+import org.mozilla.zest.core.v1.ZestRequest;
 import org.mozilla.zest.core.v1.ZestResponse;
+import org.mozilla.zest.core.v1.ZestScript;
+import org.mozilla.zest.impl.ZestBasicRunner;
 
 
 /**
@@ -109,6 +117,27 @@ public class ZestAssignRegexDelimitersUnitTest {
 			// Expected
 		}
 		
+	}
+	
+	/**
+	 * Method testAssignRegexDelimitersZestScript.
+	 * Test a zest script. Uses ZestJSON and ZestBasicRunner directly as ZestActionInvoke don't use the ZestResponse now.
+	 * @throws Exception
+	 */
+	@Test
+	public void testAssignRegexDelimitersZestScript() throws Exception {
+		ZestResponse resp = new ZestResponse(null, "Server: Apache-Coyote/1.1\r\nLocation: http://some.url.com\r\nExpires: Wed, 12 Jul 2017 11:26:32 GMT", "Body Prefix54321Postfix", 302, 0);
+		ZestRequest req = new ZestRequest();
+		req.setResponse(resp);
+		
+		String zestString = IOUtils.toString(getClass().getResource("/data/assignRegexDelimiters-script.zest"));
+		ZestScript zestScript = (ZestScript) ZestJSON.fromString(zestString);
+		
+		Map<String, String> map = new HashMap<>();
+		ZestBasicRunner runner = new ZestBasicRunner();
+		String result = runner.run(zestScript, req, map);
+		
+		assertEquals ("http://some.url.com", result);
 	}
 
 }

--- a/src/test/resources/data/assignRegexDelimiters-script.zest
+++ b/src/test/resources/data/assignRegexDelimiters-script.zest
@@ -1,0 +1,32 @@
+{
+  "about": "This is a Zest script. For more details about Zest visit https://developer.mozilla.org/en-US/docs/Zest",
+  "zestVersion": "0.3",
+  "title": "Simple test script",
+  "description": "",
+  "prefix": "",
+  "type": "StandAlone",
+  "parameters": {
+    "tokenStart": "{{",
+    "tokenEnd": "}}",
+    "tokens": {},
+    "elementType": "ZestVariables"
+  },
+  "statements": [
+    {      
+      "variableName": "test",
+      "index": 1,
+      "elementType": "ZestAssignRegexDelimiters",
+      "postfix": "[\r\n]+",
+      "prefix": "Location: ",
+      "location": "HEAD"
+    },
+    {
+      "value": "{{test}}",
+      "index": 2,
+      "elementType": "ZestControlReturn"
+    }
+  ],
+  "authentication": [],
+  "index": 0,
+  "elementType": "ZestScript"
+}


### PR DESCRIPTION
When using zaproxy with a custom authentication zest script using regexp assignement, I encounter a NullPointerException in ZestAssignRegexDelimiters.
It looks like the JSON framework is using field reflexion, so the prefix and postfix field are set but not the prefixPattern and postfixPattern ones (are they are transient).
The fix just check the regexp patterns before using them, recreating them if needed.