### PR TITLE
Remove misplaced license headers

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionAnd.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionAnd.java
@@ -8,11 +8,6 @@ import java.util.List;
 
 // TODO: Auto-generated Javadoc
 /**
- * 
- /* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file, You
- * can obtain one at http://mozilla.org/MPL/2.0/.
- * 
  * This class represent a List of AND clauses
  * 
  * @author Alessandro Secco: seccoale@gmail.com

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionElement.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionElement.java
@@ -5,11 +5,6 @@ package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc
 /**
- * 
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
  * this interface represents a Conditional Element, such as a simple<br>
  * Coditional (based on regex, Status Code, ..) or a list of AND/OR<br>
  * clauses


### PR DESCRIPTION
Remove license header from JavaDoc of the classes ZestExpressionElement
and ZestExpressionAnd.