### PR TITLE
Remove redundant toString call in ZestJSON

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestJSON.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestJSON.java
@@ -31,7 +31,7 @@ public class ZestJSON implements JsonDeserializer<ZestElement>, JsonSerializer<Z
 	 * @return the string
 	 */
 	public static String toString(ZestElement element) {
-		return getGson().toJson(element).toString();
+		return getGson().toJson(element);
 	}
 	
 	/**


### PR DESCRIPTION
The returned object is already a String.