### PR TITLE
Correct subtract operation in ZestAssignCalc

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignCalc.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignCalc.java
@@ -63,7 +63,7 @@ public class ZestAssignCalc extends ZestAssignment {
 		if (OPERAND_ADD.equals(operation)) {
 			return Integer.toString(operA + operB);
 		} else if (OPERAND_SUBTRACT.equals(operation)) {
-			return Integer.toString(operA + operB);
+			return Integer.toString(operA - operB);
 		} else if (OPERAND_MULTIPLY.equals(operation)) {
 			return Integer.toString(operA * operB);
 		} else if (OPERAND_DIVIDE.equals(operation)) {


### PR DESCRIPTION
Change ZestAssignCalc to use minus operator in subtract operation (it
was using the plus operator).