### PR TITLE
Use the var in the constructor of ZestActionInvoke

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionInvoke.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionInvoke.java
@@ -54,6 +54,7 @@ public class ZestActionInvoke extends ZestAction {
 	public ZestActionInvoke(String script, String variableName, List<String[]> parameters) {
 		super();
 		this.script = script;
+		this.variableName = variableName;
 		this.parameters = parameters;
 	}
 

--- a/src/test/java/org/mozilla/zest/test/v1/ZestActionInvokeUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestActionInvokeUnitTest.java
@@ -5,6 +5,7 @@ package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -18,6 +19,20 @@ import org.mozilla.zest.core.v1.ZestResponse;
 /**
  */
 public class ZestActionInvokeUnitTest {
+
+	@Test
+	public void shouldUseArgsPassedInConstructor() throws Exception {
+		// Given
+		String script = "script.js";
+		String variable = "var";
+		List<String[]> parameters = new ArrayList<>();
+		// When
+		ZestActionInvoke invokeAction = new ZestActionInvoke(script, variable, parameters);
+		// Then
+		assertEquals(invokeAction.getScript(), script);
+		assertEquals(invokeAction.getVariableName(), variable);
+		assertEquals(invokeAction.getParameters(), parameters);
+	}
 
 	/**
 	 * Method testSimpleJsScript.


### PR DESCRIPTION
Change ZestActionInvoke to use the variable passed in the constructor.
Add test to assert the expected behaviour.