### PR TITLE
Validate response provided on assign field value

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignFieldValue.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignFieldValue.java
@@ -71,6 +71,10 @@ public class ZestAssignFieldValue extends ZestAssignment {
 
 	@Override
 	public String assign(ZestResponse response, ZestRuntime runtime) throws ZestAssignFailException {
+		if (response == null) {
+			throw new ZestAssignFailException(this, "Null response");
+		}
+
 		Source src = new Source(response.getHeaders() + response.getBody());
 		List<Element> formElements = src.getAllElements(HTMLElementName.FORM);
 

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignFieldValueUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignFieldValueUnitTest.java
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.zest.test.v1;
+
+import org.junit.Test;
+import org.mozilla.zest.core.v1.ZestAssignFailException;
+import org.mozilla.zest.core.v1.ZestAssignFieldValue;
+import org.mozilla.zest.core.v1.ZestFieldDefinition;
+import org.mozilla.zest.core.v1.ZestResponse;
+
+/**
+ * Unit test for {@link ZestAssignFieldValue}.
+ */
+public class ZestAssignFieldValueUnitTest {
+
+    @Test(expected = ZestAssignFailException.class)
+    public void shouldFailTheAssignIfResponseIsNotProvided() throws Exception {
+        // Given
+        ZestResponse response = null;
+        ZestAssignFieldValue assignFieldValue = new ZestAssignFieldValue("Var", new ZestFieldDefinition(0, "Field"));
+        // When
+        assignFieldValue.assign(response, new TestRuntime());
+        // Then = ZestAssignFailException
+    }
+
+}


### PR DESCRIPTION
Change ZestAssignFieldValue to validate that the response is provided
(throwing a ZestAssignFailException if not, throws a more descriptive
exception than NullPointerException).
Add test to assert the expected behaviour.