### PR TITLE
Update Selenium library to version 3.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 group 'org.mozilla'
 version '0.13-SNAPSHOT'
@@ -30,7 +30,7 @@ dependencies {
              'com.google.code.gson:gson:2.2.2',
              'com.opera:operadriver:1.5',
              'com.github.detro.ghostdriver:phantomjsdriver:1.1.0',
-             'org.seleniumhq.selenium:selenium-server:2.43.0',
+             'org.seleniumhq.selenium:selenium-server:3.4.0',
              'net.htmlparser.jericho:jericho-html:3.1')
 
     testCompile('junit:junit:4.11')

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientLaunch.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientLaunch.java
@@ -121,7 +121,7 @@ public class ZestClientLaunch extends ZestClient {
 			} else if ("Chrome".equalsIgnoreCase(this.browserType)) {
 				driver = new ChromeDriver(cap); 
 			} else if ("HtmlUnit".equalsIgnoreCase(this.browserType)) {
-				driver = new HtmlUnitDriver(cap); 
+				driver = new HtmlUnitDriver(DesiredCapabilities.htmlUnit().merge(cap)); 
 			} else if ("InternetExplorer".equalsIgnoreCase(this.browserType)) {
 				driver = new InternetExplorerDriver(cap); 
 			} else if ("Opera".equalsIgnoreCase(this.browserType)) {

--- a/src/test/java/org/mozilla/zest/test/v1/ZestClientLaunchUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestClientLaunchUnitTest.java
@@ -69,8 +69,12 @@ public class ZestClientLaunchUnitTest {
 	@Test
 	public void testHtmlUnitByClassLaunch() throws Exception {
 		ZestScript script = new ZestScript();
-		script.add(new ZestClientLaunch("htmlunit", "org.openqa.selenium.htmlunit.HtmlUnitDriver", 
-				"http://localhost:" + PORT + "/test"));
+		ZestClientLaunch cl = new ZestClientLaunch(
+				"htmlunit",
+				"org.openqa.selenium.htmlunit.HtmlUnitDriver",
+				"http://localhost:" + PORT + "/test");
+		cl.setCapabilities("browserName=htmlunit");
+		script.add(cl);
 		script.add(new ZestClientWindowClose("htmlunit", 0));
 	
 		ZestBasicRunner runner = new ZestBasicRunner();


### PR DESCRIPTION
Update Selenium library to version 3.4.0 and Java version to 8, Selenium
requires the newer Java version.
Update ZestClientLaunch and ZestClientLaunchUnitTest to conform to
latest version.

Related to zaproxy/zaproxy#3509 - Update Selenium library to version 3.x