### PR TITLE
Remove redundant interface specification

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestStructuredExpression.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestStructuredExpression.java
@@ -16,7 +16,7 @@ import java.util.List;
 /**
  * The Class ZestStructuredExpression.
  */
-public abstract class ZestStructuredExpression extends ZestExpression implements ZestExpressionElement{
+public abstract class ZestStructuredExpression extends ZestExpression {
 	
 	/** The children. */
 	private List<ZestExpressionElement> children = new LinkedList<>();


### PR DESCRIPTION
Change ZestStructuredExpression to remove the implementation of
ZestExpressionElement, the base class ZestExpression already implements
the interface.