### PR TITLE
Use the var in the constructor of ZestClientLaunch

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientLaunch.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientLaunch.java
@@ -40,6 +40,7 @@ public class ZestClientLaunch extends ZestClient {
 		this.windowHandle = windowHandle;
 		this.browserType = browserType;
 		this.url = url;
+		this.capabilities = capabilities;
 	}
 
 	public ZestClientLaunch() {

--- a/src/test/java/org/mozilla/zest/test/v1/ZestClientLaunchUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestClientLaunchUnitTest.java
@@ -54,6 +54,37 @@ public class ZestClientLaunchUnitTest {
 	}
 
 	@Test
+	public void shouldUseArgsPassedInConstructor() throws Exception {
+		// Given
+		String windowHandle = "windowHandle";
+		String browserType = "browserType";
+		String url = "url";
+		// When
+		ZestClientLaunch invokeAction = new ZestClientLaunch(windowHandle, browserType, url);
+		// Then
+		assertEquals(invokeAction.getWindowHandle(), windowHandle);
+		assertEquals(invokeAction.getBrowserType(), browserType);
+		assertEquals(invokeAction.getUrl(), url);
+		assertEquals(invokeAction.getCapabilities(), null);
+	}
+
+	@Test
+	public void shouldUseArgsPassedInConstructorWithCapabilities() throws Exception {
+		// Given
+		String windowHandle = "windowHandle";
+		String browserType = "browserType";
+		String url = "url";
+		String capabilities = "capability=value";
+		// When
+		ZestClientLaunch invokeAction = new ZestClientLaunch(windowHandle, browserType, url, capabilities);
+		// Then
+		assertEquals(invokeAction.getWindowHandle(), windowHandle);
+		assertEquals(invokeAction.getBrowserType(), browserType);
+		assertEquals(invokeAction.getUrl(), url);
+		assertEquals(invokeAction.getCapabilities(), capabilities);
+	}
+
+	@Test
 	public void testHtmlUnitLaunch() throws Exception {
 		ZestScript script = new ZestScript();
 		script.add(new ZestClientLaunch("htmlunit", "HtmlUnit", "http://localhost:" + PORT + "/test"));


### PR DESCRIPTION
Change ZestClientLaunch to use the variable passed in the constructor.
Add test to assert the expected behaviour.