### PR TITLE
Use try-with-resource stmt whenever possible

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenFileSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenFileSet.java
@@ -42,18 +42,18 @@ public class ZestLoopTokenFileSet extends ZestElement implements ZestLoopTokenSe
 	 * @throws FileNotFoundException if the file does not exist
 	 */
 	private ZestLoopTokenStringSet getConvertedSet(File file) throws FileNotFoundException {
-		if(this.convertedSet==null){
-		Scanner in = new Scanner(file);
-		ZestLoopTokenStringSet initializationSet = new ZestLoopTokenStringSet();
-		String line;
-		while (in.hasNextLine()) {
-			line = in.nextLine();
-			if (!line.startsWith("#") && !line.isEmpty()) {//discards commented and empty line
-				initializationSet.addToken(line);
+		if (this.convertedSet == null) {
+			try (Scanner in = new Scanner(file)) {
+				ZestLoopTokenStringSet initializationSet = new ZestLoopTokenStringSet();
+				String line;
+				while (in.hasNextLine()) {
+					line = in.nextLine();
+					if (!line.startsWith("#") && !line.isEmpty()) {// discards commented and empty line
+						initializationSet.addToken(line);
+					}
+				}
+				this.convertedSet = initializationSet;
 			}
-		}
-		in.close();
-		this.convertedSet=initializationSet;
 		}
 		return convertedSet;
 	}

--- a/src/main/java/org/mozilla/zest/impl/CmdLine.java
+++ b/src/main/java/org/mozilla/zest/impl/CmdLine.java
@@ -128,14 +128,12 @@ public class CmdLine {
 		}
 
 		StringBuilder sb;
-		try {
-			BufferedReader fr = new BufferedReader(new FileReader(script));
+		try (BufferedReader fr = new BufferedReader(new FileReader(script))) {
 			sb = new StringBuilder();
 			String line;
 			while ((line = fr.readLine()) != null) {
 			    sb.append(line);
 			}
-			fr.close();
 		} catch (Exception e) {
 			error("Error reading file " + script.getAbsolutePath() + ": " + e);
 			return;

--- a/src/main/java/org/mozilla/zest/impl/ZestBasicRunner.java
+++ b/src/main/java/org/mozilla/zest/impl/ZestBasicRunner.java
@@ -432,13 +432,13 @@ public class ZestBasicRunner implements ZestRunner, ZestRuntime {
 			throws ZestAssertFailException, ZestActionFailException,
 			IOException, ZestInvalidCommonTestException,
 			ZestAssignFailException, ZestClientFailException {
-		BufferedReader fr = new BufferedReader(reader);
 		StringBuilder sb = new StringBuilder();
-		String line;
-		while ((line = fr.readLine()) != null) {
-			sb.append(line);
+		try (BufferedReader fr = new BufferedReader(reader)) {
+			String line;
+			while ((line = fr.readLine()) != null) {
+				sb.append(line);
+			}
 		}
-		fr.close();
 		return run((ZestScript) ZestJSON.fromString(sb.toString()), params);
 	}
 


### PR DESCRIPTION
Change CmdLine, ZestBasicRunner, and ZestLoopTokenFileSet to use
try-with-resource statement to ensure the resources are always closed.