### PR TITLE
Update Selenium and PhantomJS driver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ dependencies {
     compile ('commons-httpclient:commons-httpclient:3.1',
              'com.google.code.gson:gson:2.2.2',
              'com.opera:operadriver:1.5',
-             'com.github.detro.ghostdriver:phantomjsdriver:1.1.0',
-             'org.seleniumhq.selenium:selenium-server:3.4.0',
+             'com.codeborne:phantomjsdriver:1.4.3',
+             'org.seleniumhq.selenium:selenium-server:3.5.3',
              'net.htmlparser.jericho:jericho-html:3.1')
 
     testCompile('junit:junit:4.11')

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopClientElementUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopClientElementUnitTest.java
@@ -101,7 +101,7 @@ public class ZestLoopClientElementUnitTest {
 		runner.setOutputWriter(sw);
 		runner.run(script, null);
 		
-		assertEquals("text\n" + "password\n" + "submit\n", sw.toString());
+		assertEquals("text\n" + "password\n" + "select-one\n" + "submit\n", sw.toString());
 		
 	}
 


### PR DESCRIPTION
Update Selenium to 3.5.3 and PhantomJS driver to 1.4.3 (which uses a
newer version of Selenium).
Update test to match the new behaviour (select's type is now returned),
test passes with Chrome (59), Firefox (55), PhantomJS (2.1.1), and
Htmlunit (2.27, version bundled in Selenium).

Related to zaproxy/zaproxy#3830 - Update to Selenium 3.5