### PR TITLE
Start browsers in headless mode by default

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientLaunch.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientLaunch.java
@@ -9,7 +9,9 @@ import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriver;
@@ -26,21 +28,33 @@ import com.opera.core.systems.OperaDriver;
  */
 public class ZestClientLaunch extends ZestClient {
 
+	private static final String HEADLESS_ARG = "--headless";
+
 	private String windowHandle = null;
 	private String browserType = null;
 	private String url = null;
 	private String capabilities = null;
+	private boolean headless = true;
 
 	public ZestClientLaunch(String windowHandle, String browserType, String url) {
 		this(windowHandle, browserType, url, null);
 	}
 
+	public ZestClientLaunch(String windowHandle, String browserType, String url, boolean headless) {
+		this(windowHandle, browserType, url, null, headless);
+	}
+
 	public ZestClientLaunch(String windowHandle, String browserType, String url, String capabilities) {
+		this(windowHandle, browserType, url, capabilities, true);
+	}
+
+	public ZestClientLaunch(String windowHandle, String browserType, String url, String capabilities, boolean headless) {
 		super();
 		this.windowHandle = windowHandle;
 		this.browserType = browserType;
 		this.url = url;
 		this.capabilities = capabilities;
+		this.headless = headless;
 	}
 
 	public ZestClientLaunch() {
@@ -77,6 +91,14 @@ public class ZestClientLaunch extends ZestClient {
 
 	public void setCapabilities(String capabilities) {
 		this.capabilities = capabilities;
+	}
+
+	public boolean isHeadless() {
+		return headless;
+	}
+
+	public void setHeadless(boolean headless) {
+		this.headless = headless;
 	}
 
 	@Override
@@ -118,8 +140,20 @@ public class ZestClientLaunch extends ZestClient {
 			}
 
 			if ("Firefox".equalsIgnoreCase(this.browserType)) {
+				if (isHeadless()) {
+					FirefoxOptions firefoxOptions = new FirefoxOptions();
+					firefoxOptions.addArguments(HEADLESS_ARG);
+					firefoxOptions.addTo(cap);
+				}
+
 				driver = new FirefoxDriver(cap);
 			} else if ("Chrome".equalsIgnoreCase(this.browserType)) {
+				if (isHeadless()) {
+					ChromeOptions chromeOptions = new ChromeOptions();
+					chromeOptions.addArguments(HEADLESS_ARG);
+					cap.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
+				}
+
 				driver = new ChromeDriver(cap); 
 			} else if ("HtmlUnit".equalsIgnoreCase(this.browserType)) {
 				driver = new HtmlUnitDriver(DesiredCapabilities.htmlUnit().merge(cap)); 

--- a/src/test/java/org/mozilla/zest/test/v1/ZestClientLaunchUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestClientLaunchUnitTest.java
@@ -126,7 +126,7 @@ public class ZestClientLaunchUnitTest {
 
 	@Test
 	public void testSerialization() {
-		ZestClientLaunch zcl1 = new ZestClientLaunch("htmlunit", "HtmlUnit", "http://localhost:" + PORT + "/test");
+		ZestClientLaunch zcl1 = new ZestClientLaunch("htmlunit", "HtmlUnit", "http://localhost:" + PORT + "/test", false);
 		String str = ZestJSON.toString(zcl1);
 		ZestClientLaunch zcl2 = (ZestClientLaunch) ZestJSON.fromString(str);
 		
@@ -134,5 +134,6 @@ public class ZestClientLaunchUnitTest {
 		assertEquals(zcl1.getBrowserType(), zcl2.getBrowserType());
 		assertEquals(zcl1.getWindowHandle(), zcl2.getWindowHandle());
 		assertEquals(zcl1.getUrl(), zcl2.getUrl());
+		assertEquals(zcl1.isHeadless(), zcl2.isHeadless());
 	}
 }


### PR DESCRIPTION
Change ZestClientLaunch to allow to set if the browsers should be
started in headless mode or not, also, set to start in headless mode by
default. The change just affects Chrome and Firefox which now allow to
run in headless mode.
Update test to assert the new behaviour.