### PR TITLE
Update JavaDoc link

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ tasks.withType(JavaCompile) {
 
 tasks.withType(Javadoc) {
     options {
-        links = [ 'http://docs.oracle.com/javase/7/docs/api/' ]
+        links = [ 'https://docs.oracle.com/javase/8/docs/api/' ]
         encoding = 'UTF-8'
     }
     if (JavaVersion.current().isJava8Compatible()) {


### PR DESCRIPTION
Update Java's JavaDoc link to point to Java 8 and use HTTPS.