### PR TITLE
Tweak sleep test assertion

### DIFF
--- a/src/test/java/org/mozilla/zest/test/v1/ZestActionSleepUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestActionSleepUnitTest.java
@@ -23,8 +23,9 @@ public class ZestActionSleepUnitTest {
 	 */
 	@Test
 	public void testSimpleJsScript() throws Exception {
+		long sleepTime = 1000;
 		ZestActionSleep inv = new ZestActionSleep();
-		inv.setMilliseconds(1000);
+		inv.setMilliseconds(sleepTime);
 		TestRuntime rt = new TestRuntime();
 		
 		ZestResponse resp = new ZestResponse(null, "Header prefix12345postfix", "Body Prefix54321Postfix", 200, 0);
@@ -32,9 +33,9 @@ public class ZestActionSleepUnitTest {
 		String result = inv.invoke(resp, rt);
 		Date end = new Date();
 
-		assertEquals ("1000", result);
+		assertEquals (String.valueOf(sleepTime), result);
 		// Make sure its within 5% or expected time
-		assertEquals ((end.getTime() - start.getTime())/5, 200);
+		assertEquals (sleepTime, end.getTime() - start.getTime(), sleepTime * 0.05);
 	}
 
 	@Test


### PR DESCRIPTION
Change ZestActionSleepUnitTest to use an assertion with delta when
checking time slept, also, swap the values (to have expected value and
actual value in the expected positions) and extract the sleep time into
a variable.
The reason to do the change was that the test failed:
   AssertionError: expected:<201> but was:<200>
while it was still within the expected margin.