### PR TITLE
Be more lenient when checking script type

### DIFF
--- a/src/main/java/org/mozilla/zest/impl/ZestBasicRunner.java
+++ b/src/main/java/org/mozilla/zest/impl/ZestBasicRunner.java
@@ -172,8 +172,7 @@ public class ZestBasicRunner implements ZestRunner, ZestRuntime {
 		if (skipStatements || ! stmt.isEnabled()) {
 			return lastRes;
 		}
-		if (script.getType() != null && ZestScript.Type.Passive.equals(ZestScript.Type.valueOf(script.getType()))
-				&& !stmt.isPassive()) {
+		if (script.isPassive() && !stmt.isPassive()) {
 			throw new IllegalArgumentException(stmt.getElementType()
 					+ " not allowed in passive scripts");
 		}


### PR DESCRIPTION
Change ZestScript to convert the string type to Type in a case
insensitive manner to prevent case differences from "breaking" the
scripts. Also, ensure the name used is the one of the Type.
Change ZestBasicRunner to use ZestScript.isPassive() instead of checking
the type manually.