### PR TITLE
Fail to open URL if no window handle found

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientWindowOpenUrl.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientWindowOpenUrl.java
@@ -58,8 +58,7 @@ public class ZestClientWindowOpenUrl extends ZestClient {
 		WebDriver wd = runtime.getWebDriver(this.getWindowHandle());
 		
 		if (wd == null) {
-			// No point throwing an exception as we were going to close it anyway
-			return null;
+			throw new ZestClientFailException(this, "No client: " + runtime.getVariable(getWindowHandle()));
 		}
 		
 		String targetUrl = runtime.replaceVariablesInString(url, true);

--- a/src/test/java/org/mozilla/zest/test/v1/ZestClientWindowOpenUrlUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestClientWindowOpenUrlUnitTest.java
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.zest.test.v1;
+
+import org.junit.Test;
+import org.mozilla.zest.core.v1.ZestClientFailException;
+import org.mozilla.zest.core.v1.ZestClientWindowOpenUrl;
+
+/**
+ * Unit test for {@link ZestClientWindowOpenUrl}.
+ */
+public class ZestClientWindowOpenUrlUnitTest {
+
+    @Test(expected = ZestClientFailException.class)
+    public void shouldFailToOpenUrlIfWindowHandleNotFound() throws Exception {
+        // Given
+        ZestClientWindowOpenUrl openUrl = new ZestClientWindowOpenUrl("NoWindowHandle", "http://no.wd.localhost/");
+        // When
+        openUrl.invoke(testRuntime());
+        // Then = ZestClientFailException
+    }
+
+    private static TestRuntime testRuntime() {
+        return new TestRuntime();
+    }
+}


### PR DESCRIPTION
Change ZestClientWindowOpenUrl to throw an exception if the window
handle (WebDriver) was not found, like done in other client actions.
Add test to assert the expected behaviour.