### PR TITLE
Add an expression to check the protocol

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionProtocol.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionProtocol.java
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.zest.core.v1;
+
+import java.net.URL;
+
+/**
+ * A {@link ZestExpression} that checks if the {@link ZestRuntime#getLastRequest() last request} has a given protocol (for
+ * example, HTTPS).
+ * <p>
+ * The check is done in a case-insensitive manner. The expression returns {@code false} if no protocol was set (that is,
+ * {@code null}).
+ * 
+ * @since 0.14
+ */
+public class ZestExpressionProtocol extends ZestExpression {
+
+    private String protocol;
+
+    /**
+     * Constructs a {@code ZestExpressionProtocol} with no protocol.
+     */
+    public ZestExpressionProtocol() {
+        super();
+    }
+
+    /**
+     * Constructs a {@code ZestExpressionProtocol} with the given protocol.
+     * 
+     * @param protocol the protocol that the request must have for the expression to return {@code true}.
+     */
+    public ZestExpressionProtocol(String protocol) {
+        super();
+        this.protocol = protocol;
+    }
+
+    /**
+     * Tells whether or not the {@link ZestRuntime#getLastRequest() last request} matches {@link #getProtocol() the protocol}
+     * set.
+     */
+    @Override
+    public boolean isTrue(ZestRuntime runtime) {
+        if (protocol == null) {
+            return false;
+        }
+
+        ZestRequest request = runtime.getLastRequest();
+        if (request == null) {
+            return false;
+        }
+
+        URL url = request.getUrl();
+        if (url == null) {
+            return false;
+        }
+
+        return protocol.equalsIgnoreCase(url.getProtocol());
+    }
+
+    /**
+     * Gets the protocol that the request must have.
+     *
+     * @return the protocol, might be {@code null}.
+     */
+    public String getProtocol() {
+        return protocol;
+    }
+
+    /**
+     * Sets the protocol that the request must have.
+     *
+     * @param protocol the new protocol
+     */
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    @Override
+    public ZestExpressionProtocol deepCopy() {
+        ZestExpressionProtocol copy = new ZestExpressionProtocol(protocol);
+        copy.setInverse(isInverse());
+        return copy;
+    }
+
+    @Override
+    public String toString() {
+        return (isInverse() ? "NOT " : "") + "Protocol: " + protocol;
+    }
+
+}

--- a/src/main/java/org/mozilla/zest/impl/ZestPrinter.java
+++ b/src/main/java/org/mozilla/zest/impl/ZestPrinter.java
@@ -25,6 +25,7 @@ import org.mozilla.zest.core.v1.ZestExpressionEquals;
 import org.mozilla.zest.core.v1.ZestExpressionIsInteger;
 import org.mozilla.zest.core.v1.ZestExpressionLength;
 import org.mozilla.zest.core.v1.ZestExpressionOr;
+import org.mozilla.zest.core.v1.ZestExpressionProtocol;
 import org.mozilla.zest.core.v1.ZestExpressionRegex;
 import org.mozilla.zest.core.v1.ZestExpressionResponseTime;
 import org.mozilla.zest.core.v1.ZestExpressionStatusCode;
@@ -249,6 +250,9 @@ public class ZestPrinter {
 			} else if (element instanceof ZestExpressionURL) {
 				// ZestExpressionURL urlExpr=(ZestExpressionURL)element;
 				System.out.print("URL ");
+			} else if (element instanceof ZestExpressionProtocol) {
+				ZestExpressionProtocol lengthExpr = (ZestExpressionProtocol) element;
+				System.out.print("Protocol: " + lengthExpr.getProtocol());
 			}
 		} else {
 			printIndent(indent);

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionProtocolUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionProtocolUnitTest.java
@@ -1,0 +1,183 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.zest.test.v1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+
+import org.junit.Test;
+import org.mozilla.zest.core.v1.ZestExpressionProtocol;
+import org.mozilla.zest.core.v1.ZestJSON;
+import org.mozilla.zest.core.v1.ZestRequest;
+
+/**
+ * Unit test for {@link ZestExpressionProtocol}.
+ */
+public class ZestExpressionProtocolUnitTest {
+
+    @Test
+    public void shouldNotHaveProtocolByDefault() {
+        // Given / When
+        ZestExpressionProtocol protocolExpression = new ZestExpressionProtocol();
+        // Then
+        assertTrue(protocolExpression.getProtocol() == null);
+    }
+
+    @Test
+    public void shouldNotBeInversedByDefault() {
+        // Given / When
+        ZestExpressionProtocol protocolExpression = new ZestExpressionProtocol();
+        // Then
+        assertFalse(protocolExpression.isInverse());
+    }
+
+    @Test
+    public void shouldSetProtocol() {
+        // Given
+        String protocol = "http";
+        ZestExpressionProtocol protocolExpression = new ZestExpressionProtocol();
+        // When
+        protocolExpression.setProtocol(protocol);
+        // Then
+        assertEquals(protocol, protocolExpression.getProtocol());
+    }
+
+    @Test
+    public void shouldSetInverse() {
+        // Given
+        ZestExpressionProtocol protocolExpression = new ZestExpressionProtocol();
+        // When
+        protocolExpression.setInverse(true);
+        // Then
+        assertTrue(protocolExpression.isInverse());
+    }
+
+    @Test
+    public void shouldDeepCopy() {
+        // Given
+        ZestExpressionProtocol protocolExpression = new ZestExpressionProtocol("https");
+        protocolExpression.setInverse(true);
+        // When
+        ZestExpressionProtocol copyProtocolExpression = protocolExpression.deepCopy();
+        // Then
+        assertTrue(copyProtocolExpression != protocolExpression);
+        assertEquals(copyProtocolExpression.getProtocol(), protocolExpression.getProtocol());
+        assertEquals(copyProtocolExpression.isInverse(), protocolExpression.isInverse());
+    }
+
+    @Test
+    public void shouldEvaluateToFalseIfNoProtocolSet() throws Exception {
+        // Given
+        ZestExpressionProtocol protocolExpression = new ZestExpressionProtocol();
+        ZestRequest request = createRequest("http://localhost/");
+        // When
+        boolean result = protocolExpression.evaluate(new TestRuntime(request));
+        // Then
+        assertFalse(result);
+    }
+
+    @Test
+    public void shouldEvaluateToFalseIfNoRequest() throws Exception {
+        // Given
+        ZestExpressionProtocol protocolExpression = new ZestExpressionProtocol("http");
+        // When
+        boolean result = protocolExpression.evaluate(new TestRuntime());
+        // Then
+        assertFalse(result);
+    }
+
+    @Test
+    public void shouldEvaluateToFalseIfRequestButNoUrl() throws Exception {
+        // Given
+        ZestExpressionProtocol protocolExpression = new ZestExpressionProtocol("http");
+        ZestRequest request = createRequest();
+        // When
+        boolean result = protocolExpression.evaluate(new TestRuntime(request));
+        // Then
+        assertFalse(result);
+    }
+
+    @Test
+    public void shouldEvaluateToTrueIfSameProtocol() throws Exception {
+        // Given
+        ZestExpressionProtocol protocolExpression = new ZestExpressionProtocol("http");
+        ZestRequest request = createRequest("http://localhost/");
+        // When
+        boolean result = protocolExpression.evaluate(new TestRuntime(request));
+        // Then
+        assertTrue(result);
+    }
+
+    @Test
+    public void shouldEvaluateToTrueIfSameProtocolWithDifferenceCase() throws Exception {
+        // Given
+        ZestExpressionProtocol protocolExpression = new ZestExpressionProtocol("HTTP");
+        ZestRequest request = createRequest("http://localhost/");
+        // When
+        boolean result = protocolExpression.evaluate(new TestRuntime(request));
+        // Then
+        assertTrue(result);
+    }
+
+    @Test
+    public void shouldEvaluateToFalseIfInverseAndSameProtocol() throws Exception {
+        // Given
+        ZestExpressionProtocol protocolExpression = new ZestExpressionProtocol("http");
+        protocolExpression.setInverse(true);
+        ZestRequest request = createRequest("http://localhost/");
+        // When
+        boolean result = protocolExpression.evaluate(new TestRuntime(request));
+        // Then
+        assertFalse(result);
+    }
+
+    @Test
+    public void shouldEvaluateToFalseIfNotSameProtocol() throws Exception {
+        // Given
+        ZestExpressionProtocol protocolExpression = new ZestExpressionProtocol("https");
+        ZestRequest request = createRequest("http://localhost/");
+        // When
+        boolean result = protocolExpression.evaluate(new TestRuntime(request));
+        // Then
+        assertFalse(result);
+    }
+
+    @Test
+    public void shouldEvaluateToTrueIfInverseAndNotSameProtocol() throws Exception {
+        // Given
+        ZestExpressionProtocol protocolExpression = new ZestExpressionProtocol("https");
+        protocolExpression.setInverse(true);
+        ZestRequest request = createRequest("http://localhost/");
+        // When
+        boolean result = protocolExpression.evaluate(new TestRuntime(request));
+        // Then
+        assertTrue(result);
+    }
+
+    @Test
+    public void shouldSerialiseAndDeserialise() {
+        // Given
+        ZestExpressionProtocol protocolExpression = new ZestExpressionProtocol("http");
+        // When
+        String serialisation = ZestJSON.toString(protocolExpression);
+        ZestExpressionProtocol deserialisedProtocolExpression = (ZestExpressionProtocol) ZestJSON.fromString(serialisation);
+        // Then
+        assertTrue(deserialisedProtocolExpression != protocolExpression);
+        assertEquals(deserialisedProtocolExpression.getProtocol(), protocolExpression.getProtocol());
+        assertEquals(deserialisedProtocolExpression.isInverse(), protocolExpression.isInverse());
+    }
+
+    private static ZestRequest createRequest() {
+        return new ZestRequest();
+    }
+
+    private static ZestRequest createRequest(String url) throws Exception {
+        ZestRequest request = createRequest();
+        request.setUrl(new URL(url));
+        return request;
+    }
+}


### PR DESCRIPTION
Add an expression, ZestExpressionProtocol, to check the protocol of the
last request sent.
Add tests to assert the expected behaviour.
Update ZestPrinter to print the new expression.

Fix #26 - Allow checking the request protocol