### PR TITLE
Add ZestExpression constructor with inverse state

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpression.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpression.java
@@ -11,13 +11,24 @@ public abstract class ZestExpression extends ZestElement implements
 		ZestExpressionElement {
 	
 	/** The not. */
-	private boolean not = false;
+	private boolean not;
 
 	/**
 	 * Instantiates a new zest expression.
 	 */
 	public ZestExpression() {
+		this(false);
+	}
+
+	/**
+	 * Constructs a {@code ZestExpression} with the given inverse state.
+	 * 
+	 * @param inverse the inverse state.
+	 * @since 0.14
+	 */
+	protected ZestExpression(boolean inverse) {
 		super();
+		this.not = inverse;
 	}
 
 	@Override

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionEquals.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionEquals.java
@@ -43,11 +43,10 @@ public class ZestExpressionEquals extends ZestExpression{
 	 * @param inverse the inverse
 	 */
 	public ZestExpressionEquals(String variableName, String value, boolean caseExact, boolean inverse) {
-		super ();
+		super (inverse);
 		this.variableName = variableName;
 		this.value = value;
 		this.caseExact = caseExact;
-		this.setInverse(inverse);
 	}
 	
 	@Override

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionLength.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionLength.java
@@ -33,10 +33,7 @@ public class ZestExpressionLength extends ZestExpression {
 	 * @param approx the approx
 	 */
 	public ZestExpressionLength(String variableName, int length, int approx) {
-		super();
-		this.variableName = variableName;
-		this.length = length;
-		this.approx = approx;
+		this(variableName, length, approx, false);
 	}
 
 	/**
@@ -44,12 +41,14 @@ public class ZestExpressionLength extends ZestExpression {
 	 *
 	 * @param variableName the variable name
 	 * @param length the length
-	 * @param j the approximation
-	 * @param b is inverse?
+	 * @param approx the approximation
+	 * @param inverse is inverse?
 	 */
-	public ZestExpressionLength(String variableName, int length, int j, boolean b) {
-		this(variableName, length,j);
-		this.setInverse(b);
+	public ZestExpressionLength(String variableName, int length, int approx, boolean inverse) {
+		super(inverse);
+		this.variableName = variableName;
+		this.length = length;
+		this.approx = approx;
 	}
 
 	@Override

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionRegex.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionRegex.java
@@ -49,10 +49,9 @@ public class ZestExpressionRegex extends ZestExpression{
 	 * @param inverse the inverse
 	 */
 	public ZestExpressionRegex(String variableName, String regex, boolean caseExact, boolean inverse) {
-		super ();
+		super (inverse);
 		this.variableName = variableName;
 		this.caseExact = caseExact;
-		this.setInverse(inverse);
 		this.regex = regex;
 		if (regex != null) {
 			if (caseExact) {


### PR DESCRIPTION
Add a convenience constructor to ZestExpression to specify the inverse
state.
Change extending classes to use the constructor instead of calling the
setter.