### PR TITLE
Add missing inverse state copy in expressions

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpression.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpression.java
@@ -23,7 +23,7 @@ public abstract class ZestExpression extends ZestElement implements
 	/**
 	 * Constructs a {@code ZestExpression} with the given inverse state.
 	 * 
-	 * @param inverse the inverse state.
+	 * @param inverse if the expression should be the inverse.
 	 * @since 0.14
 	 */
 	protected ZestExpression(boolean inverse) {

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionAnd.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionAnd.java
@@ -40,6 +40,7 @@ public class ZestExpressionAnd extends ZestStructuredExpression{
 			}
 		}
 		ZestExpressionAnd copy=new ZestExpressionAnd(copyChildren);
+		copy.setInverse(isInverse());
 		return copy;
 	}
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionClientElementExists.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionClientElementExists.java
@@ -30,7 +30,20 @@ public class ZestExpressionClientElementExists extends ZestExpression {
 	 * @param element the element to check for existence.
 	 */
 	public ZestExpressionClientElementExists(String windowHandle, String type, String element) {
-		super();
+		this(windowHandle, type, element, false);
+	}
+
+	/**
+	 * Constructs a {@code ZestExpressionClientElementExists} with the given data.
+	 * 
+	 * @param windowHandle the window handle.
+	 * @param type the type of the expression.
+	 * @param element the element to check for existence.
+	 * @param inverse if the expression should be the inverse.
+	 * @since 0.14
+	 */
+	public ZestExpressionClientElementExists(String windowHandle, String type, String element, boolean inverse) {
+		super(inverse);
 		this.windowHandle = windowHandle;
 		this.type = type;
 		this.element = element;
@@ -95,7 +108,7 @@ public class ZestExpressionClientElementExists extends ZestExpression {
 
 	@Override
 	public ZestExpressionClientElementExists deepCopy() {
-		return new ZestExpressionClientElementExists(this.windowHandle, this.getType(), this.getElement());
+		return new ZestExpressionClientElementExists(this.windowHandle, this.getType(), this.getElement(), isInverse());
 	}
 	
 }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionIsInteger.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionIsInteger.java
@@ -24,7 +24,18 @@ public class ZestExpressionIsInteger extends ZestExpression{
 	 * @param variableName the variableName
 	 */
 	public ZestExpressionIsInteger(String variableName) {
-		super ();
+		this(variableName, false);
+	}
+
+	/**
+	 * Construct a {@code ZestExpressionIsInteger} with the given variable name and inverse state.
+	 *
+	 * @param variableName the name of the variable to check.
+	 * @param inverse if the expression should be the inverse.
+	 * @since 0.14
+	 */
+	public ZestExpressionIsInteger(String variableName, boolean inverse) {
+		super(inverse);
 		this.variableName = variableName;
 	}
 	
@@ -68,7 +79,7 @@ public class ZestExpressionIsInteger extends ZestExpression{
 	
 	@Override
 	public ZestExpressionIsInteger deepCopy() {
-		return new ZestExpressionIsInteger(this.getVariableName());
+		return new ZestExpressionIsInteger(this.getVariableName(), isInverse());
 	}
 	
 }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionLength.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionLength.java
@@ -53,7 +53,7 @@ public class ZestExpressionLength extends ZestExpression {
 
 	@Override
 	public ZestExpressionLength deepCopy() {
-		return new ZestExpressionLength(this.variableName, this.length, this.approx);
+		return new ZestExpressionLength(this.variableName, this.length, this.approx, isInverse());
 	}
 	
 	/**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionOr.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionOr.java
@@ -52,6 +52,7 @@ public class ZestExpressionOr extends ZestStructuredExpression {
 			}
 		}
 		ZestExpressionOr copy = new ZestExpressionOr(copyChildren);
+		copy.setInverse(isInverse());
 		return copy;
 	}
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionProtocol.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionProtocol.java
@@ -31,7 +31,17 @@ public class ZestExpressionProtocol extends ZestExpression {
      * @param protocol the protocol that the request must have for the expression to return {@code true}.
      */
     public ZestExpressionProtocol(String protocol) {
-        super();
+        this(protocol, false);
+    }
+
+    /**
+     * Constructs a {@code ZestExpressionProtocol} with the given protocol and inverse state.
+     * 
+     * @param protocol the protocol that the request must have for the expression to return {@code true}.
+     * @param inverse if the expression should be the inverse.
+     */
+    public ZestExpressionProtocol(String protocol, boolean inverse) {
+        super(inverse);
         this.protocol = protocol;
     }
 
@@ -78,9 +88,7 @@ public class ZestExpressionProtocol extends ZestExpression {
 
     @Override
     public ZestExpressionProtocol deepCopy() {
-        ZestExpressionProtocol copy = new ZestExpressionProtocol(protocol);
-        copy.setInverse(isInverse());
-        return copy;
+        return new ZestExpressionProtocol(protocol, isInverse());
     }
 
     @Override

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionResponseTime.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionResponseTime.java
@@ -11,7 +11,7 @@ package org.mozilla.zest.core.v1;
 public class ZestExpressionResponseTime extends ZestExpression {
 	
 	/** The greater than. */
-	private boolean greaterThan = true;
+	private boolean greaterThan;
 	
 	/** The time in ms. */
 	private long timeInMs;
@@ -20,7 +20,7 @@ public class ZestExpressionResponseTime extends ZestExpression {
 	 * Instantiates a new zest expression response time.
 	 */
 	public ZestExpressionResponseTime() {
-		super();
+		this(0);
 	}
 	
 	/**
@@ -29,8 +29,34 @@ public class ZestExpressionResponseTime extends ZestExpression {
 	 * @param time the time
 	 */
 	public ZestExpressionResponseTime(long time) {
-		super();
-		this.timeInMs=time;
+		this(time, true);
+	}
+
+	/**
+	 * Constructs a {@code ZestExpressionResponseTime} with the given time and whether the response should be greater than the
+	 * given time.
+	 *
+	 * @param time the time in milliseconds.
+	 * @param greaterThan if the response time should be greater than the given time.
+	 * @since 0.14
+	 */
+	public ZestExpressionResponseTime(long time, boolean greaterThan) {
+		this(time, greaterThan, false);
+	}
+
+	/**
+	 * Constructs a {@code ZestExpressionResponseTime} with the given time, whether the response should be greater than the
+	 * given time, and with the given inverse state.
+	 *
+	 * @param time the time in milliseconds.
+	 * @param greaterThan if the response time should be greater than the given time.
+	 * @param inverse if the expression should be the inverse.
+	 * @since 0.14
+	 */
+	public ZestExpressionResponseTime(long time, boolean greaterThan, boolean inverse) {
+		super(inverse);
+		this.timeInMs = time;
+		this.greaterThan = greaterThan;
 	}
 	
 	@Override
@@ -84,10 +110,7 @@ public class ZestExpressionResponseTime extends ZestExpression {
 
 	@Override
 	public ZestExpressionResponseTime deepCopy() {
-		ZestExpressionResponseTime copy = new ZestExpressionResponseTime();
-		copy.greaterThan = this.greaterThan;
-		copy.timeInMs = this.timeInMs;
-		return copy;
+		return new ZestExpressionResponseTime(timeInMs, greaterThan, isInverse());
 	}
 	
 	@Override

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionURL.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionURL.java
@@ -139,6 +139,7 @@ public class ZestExpressionURL extends ZestExpression {
 		List<String> copyExcludeRegex = new ArrayList<>(excludeRegexes);
 		copy.setIncludeRegexes(copyIncludeRegex);
 		copy.setExcludeRegexes(copyExcludeRegex);
+		copy.setInverse(isInverse());
 		return copy;
 	}
 	

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionIsIntegerUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionIsIntegerUnitTest.java
@@ -42,9 +42,9 @@ public class ZestExpressionIsIntegerUnitTest {
 	
 	@Test
 	public void testZestExpressionIsIntegerCopy() {
-		ZestExpressionIsInteger ast = new ZestExpressionIsInteger();
-		ast.setVariableName("aaa");
+		ZestExpressionIsInteger ast = new ZestExpressionIsInteger("aaa", true);
 		ZestExpressionIsInteger ast2 =ast.deepCopy();
 		assertEquals(ast.getVariableName(), ast2.getVariableName());
+		assertEquals(ast.isInverse(), ast2.isInverse());
 	}
 }

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionLengthUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionLengthUnitTest.java
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -42,9 +43,12 @@ static {
 	}
 	@Test
 	public void testDeepCopy() {
-		ZestExpressionLength length=new ZestExpressionLength();
+		ZestExpressionLength length=new ZestExpressionLength("var", 100, 5, true);
 		ZestExpressionLength copy=length.deepCopy();
-		assertTrue(copy.getClass().equals(length.getClass()));
+		assertEquals(copy.getVariableName(), length.getVariableName());
+		assertEquals(copy.getLength(), length.getLength());
+		assertEquals(copy.getApprox(), length.getApprox());
+		assertEquals(copy.isInverse(), length.isInverse());
 	}
 	@Test
 	public void testDeepCopySameParams() {

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionResponseTimeUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionResponseTimeUnitTest.java
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -24,9 +25,11 @@ public class ZestExpressionResponseTimeUnitTest {
 
 	@Test
 	public void testDeepCopy() {
-		ZestExpressionResponseTime timeExpr=new ZestExpressionResponseTime(1000);
+		ZestExpressionResponseTime timeExpr=new ZestExpressionResponseTime(1000, false, true);
 		ZestExpressionResponseTime copy=timeExpr.deepCopy();
 		assertTrue(copy.getTimeInMs()==timeExpr.getTimeInMs());
+		assertEquals(copy.isGreaterThan(), timeExpr.isGreaterThan());
+		assertEquals(copy.isInverse(), timeExpr.isInverse());
 	}
 	@Test
 	public void testDeepCopyNoPointers() {

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionURLUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionURLUnitTest.java
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -127,7 +128,9 @@ public class ZestExpressionURLUnitTest {
 	public void testDeepCopy() {
 		ZestExpressionURL urlExpr = new ZestExpressionURL(includeStrings,
 				excludeStrings);
+		urlExpr.setInverse(true);
 		ZestExpressionURL copy = urlExpr.deepCopy();
+		assertEquals(copy.isInverse(), urlExpr.isInverse());
 		for (int i = 0; i < includeSize; i++) {
 			String obtained = copy.getIncludeRegexes().get(i);
 			String expected = includeStrings.get(i);


### PR DESCRIPTION
Change some of the expressions to also copy the inverse state in
deepCopy. Also, add convenience constructors that allow to specify the
inverse state.
Update tests to assert the new behaviour.