### PR TITLE
Add Java 9 to Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ cache:
 
 jdk:
   - oraclejdk8
+  - oraclejdk9


### PR DESCRIPTION
Change .travis.yml to also run the build with Java 9.