### PR TITLE
Ignore empty URL when launching the browser

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientLaunch.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientLaunch.java
@@ -212,7 +212,7 @@ public class ZestClientLaunch extends ZestClient {
 			
 			runtime.addWebDriver(getWindowHandle(), driver);
 			
-			if (this.url != null) {
+			if (this.url != null && !this.url.isEmpty()) {
 				driver.get(runtime.replaceVariablesInString(this.url, true));
 			}
 			


### PR DESCRIPTION
Change ZestClientLaunch to ignore the URL if also empty (preventing an
error thrown by the browser, e.g. Chrome, Firefox).