### PR TITLE
Fix ZestClientLaunch deep copy

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientLaunch.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientLaunch.java
@@ -106,7 +106,12 @@ public class ZestClientLaunch extends ZestClient {
 
 	@Override
 	public ZestStatement deepCopy() {
-		ZestClientLaunch copy = new ZestClientLaunch(this.getWindowHandle(), this.getBrowserType(), this.getUrl());
+		ZestClientLaunch copy = new ZestClientLaunch(
+				this.getWindowHandle(),
+				this.getBrowserType(),
+				this.getUrl(),
+				this.getCapabilities(),
+				this.isHeadless());
 		copy.setEnabled(this.isEnabled());
 		return copy;
 	}

--- a/src/test/java/org/mozilla/zest/test/v1/ZestClientLaunchUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestClientLaunchUnitTest.java
@@ -136,4 +136,21 @@ public class ZestClientLaunchUnitTest {
 		assertEquals(zcl1.getUrl(), zcl2.getUrl());
 		assertEquals(zcl1.isHeadless(), zcl2.isHeadless());
 	}
+
+	@Test
+	public void shouldDeepCopy() throws Exception {
+		// Given
+		ZestClientLaunch original = new ZestClientLaunch("handle", "browser", "url", "capabilities", false);
+		original.setEnabled(false);
+		// When
+		ZestClientLaunch copy = (ZestClientLaunch) original.deepCopy();
+		// Then
+		assertEquals(original.getElementType(), copy.getElementType());
+		assertEquals(original.getBrowserType(), copy.getBrowserType());
+		assertEquals(original.getWindowHandle(), copy.getWindowHandle());
+		assertEquals(original.getUrl(), copy.getUrl());
+		assertEquals(original.getCapabilities(), copy.getCapabilities());
+		assertEquals(original.isHeadless(), copy.isHeadless());
+		assertEquals(original.isEnabled(), copy.isEnabled());
+	}
 }


### PR DESCRIPTION
Change ZestClientLaunch to also copy the capabilities and the headless
state.
Add test to assert the expected behaviour.