### PR TITLE
Remove usage of com.sun classes in tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,8 @@ dependencies {
         exclude group: 'org.seleniumhq.selenium'
     }
 
-    testCompile('junit:junit:4.11')
+    testCompile('junit:junit:4.11',
+                'com.github.tomakehurst:wiremock-standalone:2.14.0')
 }
 
 jar {

--- a/src/test/java/org/mozilla/zest/test/v1/ServerBasedTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ServerBasedTest.java
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.zest.test.v1;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+import org.junit.Rule;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+/**
+ * Helper class that manages a HTTP server for use during tests.
+ */
+public abstract class ServerBasedTest {
+
+    @Rule
+    public WireMockRule server = createServer();
+
+    protected WireMockRule createServer() {
+        return new WireMockRule(options().dynamicPort(), false);
+    }
+
+    protected String getServerUrl(String path) {
+        return "http://" + server.getOptions().bindAddress() + ":" + server.port() + path;
+    }
+}

--- a/src/test/java/org/mozilla/zest/test/v1/ZestClientLaunchUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestClientLaunchUnitTest.java
@@ -3,13 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
-
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mozilla.zest.core.v1.ZestActionSleep;
@@ -20,37 +20,16 @@ import org.mozilla.zest.core.v1.ZestJSON;
 import org.mozilla.zest.core.v1.ZestScript;
 import org.mozilla.zest.impl.ZestBasicRunner;
 
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpServer;
-
 /**
  */
-public class ZestClientLaunchUnitTest {
+public class ZestClientLaunchUnitTest extends ServerBasedTest {
 
-	private static final int PORT = 8888;
-	
-	HttpServer server = null;
-	
+	private static final String PATH_SERVER_FILE = "/test";
+
 	@Before
-	public void before() throws IOException {
-		server = HttpServer.create(new InetSocketAddress(PORT), 0);
-        server.createContext("/test", new HttpHandler(){
-			@Override
-			public void handle(HttpExchange t) throws IOException {
-				String response = "This is the response";
-	            t.sendResponseHeaders(200, response.length());
-	            OutputStream os = t.getResponseBody();
-	            os.write(response.getBytes());
-	            os.close();
-			}});
-        server.setExecutor(null); // creates a default executor
-        server.start();
-	}
-
-	@After
-	public void after() throws IOException {
-		server.stop(0);
+	public void before() {
+		server.stubFor(
+				get(urlEqualTo(PATH_SERVER_FILE)).willReturn(aResponse().withStatus(200).withBody("This is the response")));
 	}
 
 	@Test
@@ -87,7 +66,7 @@ public class ZestClientLaunchUnitTest {
 	@Test
 	public void testHtmlUnitLaunch() throws Exception {
 		ZestScript script = new ZestScript();
-		script.add(new ZestClientLaunch("htmlunit", "HtmlUnit", "http://localhost:" + PORT + "/test"));
+		script.add(new ZestClientLaunch("htmlunit", "HtmlUnit", getServerUrl(PATH_SERVER_FILE), false));
 		script.add(new ZestClientWindowClose("htmlunit", 0));
 		script.add(new ZestActionSleep(1));
 	
@@ -95,6 +74,12 @@ public class ZestClientLaunchUnitTest {
 		// Uncomment this to proxy via ZAP
 		//runner.setProxy("localhost", 8090);
 		runner.run(script, null);
+		
+		verifyUrlAccessed(PATH_SERVER_FILE);
+	}
+
+	private void verifyUrlAccessed(String filePath) {
+		server.verify(getRequestedFor(urlMatching(filePath)));
 	}
 
 	@Test
@@ -103,7 +88,7 @@ public class ZestClientLaunchUnitTest {
 		ZestClientLaunch cl = new ZestClientLaunch(
 				"htmlunit",
 				"org.openqa.selenium.htmlunit.HtmlUnitDriver",
-				"http://localhost:" + PORT + "/test");
+				getServerUrl(PATH_SERVER_FILE));
 		cl.setCapabilities("browserName=htmlunit");
 		script.add(cl);
 		script.add(new ZestClientWindowClose("htmlunit", 0));
@@ -112,12 +97,14 @@ public class ZestClientLaunchUnitTest {
 		// Uncomment this to proxy via ZAP
 		//runner.setProxy("localhost", 8090);
 		runner.run(script, null);
+		
+		verifyUrlAccessed(PATH_SERVER_FILE);
 	}
 
 	@Test(expected=ZestClientFailException.class)
 	public void testInvalidName() throws Exception {
 		ZestScript script = new ZestScript();
-		script.add(new ZestClientLaunch("bad", "baddriver", "http://localhost:" + PORT + "/test"));
+		script.add(new ZestClientLaunch("bad", "baddriver", getServerUrl(PATH_SERVER_FILE)));
 		script.add(new ZestClientWindowClose("bad", 0));
 	
 		ZestBasicRunner runner = new ZestBasicRunner();
@@ -126,7 +113,7 @@ public class ZestClientLaunchUnitTest {
 
 	@Test
 	public void testSerialization() {
-		ZestClientLaunch zcl1 = new ZestClientLaunch("htmlunit", "HtmlUnit", "http://localhost:" + PORT + "/test", false);
+		ZestClientLaunch zcl1 = new ZestClientLaunch("htmlunit", "HtmlUnit", getServerUrl(PATH_SERVER_FILE), false);
 		String str = ZestJSON.toString(zcl1);
 		ZestClientLaunch zcl2 = (ZestClientLaunch) ZestJSON.fromString(str);
 		


### PR DESCRIPTION
Change ZestClientLaunchUnitTest and ZestLoopClientElementUnitTest to use
WireMock for server based tests, instead of using (com.sun) HttpServer.
Add WireMock 2.14.0 as test dependency (use standalone library, to avoid
conflicts with Selenium deps, Jetty).