### PR TITLE
Rename project to just "zest"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ For more details see the wiki: https://github.com/mozilla/zest/wiki
 ## How to Obtain
 
 If using a dependency management tool, for example [Maven](https://maven.apache.org/) or [Gradle](https://gradle.org/), the
-`mozilla-zest` library can be obtained from [Maven Central](http://search.maven.org/) with following coordinates:
+`zest` library can be obtained from [Maven Central](http://search.maven.org/) with following coordinates:
 
  * GroupId: `org.mozilla`
- * ArtifactId: `mozilla-zest`
+ * ArtifactId: `zest`
  * Version: `0.13`
 
 ## Building

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 
-rootProject.name = 'mozilla-zest'
+rootProject.name = 'zest'


### PR DESCRIPTION
Remove the "mozilla-" prefix to build the archives and artifacts with
just "zest" (also, remove redundancy from the artifact name, the group
ID already contains "mozilla").