### PR TITLE
Do not deploy distribution (zip/tar) files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,6 +159,7 @@ uploadArchives {
         mavenDeployer {
             beforeDeployment { MavenDeployment deployment ->
                 signing.signPom(deployment)
+                deployment.attachedArtifacts.removeAll { it.type =~ /^tar|zip/ }
             }
 
             repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {


### PR DESCRIPTION
Change Maven deployment to exclude the zip and tar artifacts, it's
enough deploying the Zest library (jar and sources/javadoc).