### PR TITLE
Add Java 10 to Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ cache:
 jdk:
   - oraclejdk8
   - oraclejdk9
+  - oraclejdk10


### PR DESCRIPTION
Change .travis.yml to also run the build with Java 10.