### PR TITLE
Update Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,23 +3,11 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'application'
-    id "com.diffplug.gradle.spotless" version "3.13.0"
+    id 'jacoco'
+    id "com.diffplug.gradle.spotless" version "3.23.0"
 }
-
-if (JavaVersion.current() <= JavaVersion.VERSION_1_10) {
-    // XXX Not yet supported on Java 11
-    // https://github.com/jacoco/jacoco/issues/663
-    apply plugin: 'jacoco'
-}
-
-wrapper {
-    gradleVersion = '4.8.1'
-    distributionType = Wrapper.DistributionType.ALL
-}
-
 
 repositories {
-    mavenLocal()
     mavenCentral()
 }
 
@@ -91,13 +79,13 @@ spotless {
 }
 
 task javadocJar(type: Jar) {
-    classifier = 'javadoc'
     from javadoc
+    archiveClassifier.set("javadoc")
 }
 
 task sourcesJar(type: Jar) {
     from sourceSets.main.allJava
-    classifier "sources"
+    archiveClassifier.set("sources")
 }
 
 publishing {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,2 @@
 
 rootProject.name = 'zest'
-
-enableFeaturePreview('STABLE_PUBLISHING')


### PR DESCRIPTION
Update Gradle to 5.2.1 and Spotless to 3.23.0.
Remove JaCoCo workaround and the preview feature, no longer needed.
Address deprecations when setting the JAR classifier.