### PR TITLE
Address JavaDoc issues with Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ tasks.withType(Javadoc) {
     options {
         links = [ 'https://docs.oracle.com/javase/8/docs/api/' ]
         encoding = 'UTF-8'
+        source = sourceCompatibility
     }
     if (JavaVersion.current().isJava8Compatible()) {
         options.addStringOption('Xdoclint:none', '-quiet')

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenClientElementsSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenClientElementsSet.java
@@ -51,7 +51,7 @@ public class ZestLoopTokenClientElementsSet extends ZestElement
     }
 
     /**
-     * private method for initialization of the loop (TokenSet & first state).
+     * private method for initialization of the loop (TokenSet &amp; first state).
      *
      * @return the zest loop token string set
      * @throws ZestClientFailException

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenRegexSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenRegexSet.java
@@ -53,7 +53,7 @@ public class ZestLoopTokenRegexSet extends ZestElement implements ZestLoopTokenS
     }
 
     /**
-     * private method for initialization of the loop (TokenSet & first state).
+     * private method for initialization of the loop (TokenSet &amp; first state).
      *
      * @return the zest loop token string set
      * @throws ZestClientFailException


### PR DESCRIPTION
Address warnings `invalid usage of tag &`.
Specify the source version to fix an error related to modules.