### PR TITLE
Include test stack trace when running in Travis CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,8 @@ repositories {
     mavenCentral()
 }
 
+apply from: "$rootDir/gradle/travis-ci.gradle.kts"
+
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 

--- a/gradle/travis-ci.gradle.kts
+++ b/gradle/travis-ci.gradle.kts
@@ -1,0 +1,15 @@
+// Build tweaks when running in Travis CI
+
+fun isEnvVarTrue(envvar: String) = System.getenv(envvar) == "true"
+
+if (isEnvVarTrue("TRAVIS") && isEnvVarTrue("CI")) {
+
+    allprojects {
+        tasks.withType(Test::class).configureEach {
+            testLogging {
+                exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Use full format to output the stack trace when the tests fail, to make
it easier to know where it's failing.