### PR TITLE
Add support for global variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow to obtain a screenshot from the browsers (e.g Chrome, Firefox). [#155](https://github.com/mozilla/zest/pull/155)
 - Add timestamp (unix time) to request, to indicate when it was sent. [#181](https://github.com/mozilla/zest/pull/181)
 - Command line arguments to set connection timeout and skip SSL certificate validations.
+- Add statements to set/remove and assign from global variables, provided by the runtime. [#194](https://github.com/mozilla/zest/pull/194)
 
 ### Changed
 - Update PhantomJS driver to 1.4.3. [#120](https://github.com/mozilla/zest/pull/120)

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionGlobalVariableRemove.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionGlobalVariableRemove.java
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.zest.core.v1;
+
+/**
+ * A {@link ZestAction} that removes a {@link ZestRuntime#setGlobalVariable(String, String) global
+ * variable}.
+ *
+ * @since 0.14.0
+ * @see ZestAssignGlobalVariable
+ * @see ZestActionGlobalVariableSet
+ */
+public class ZestActionGlobalVariableRemove extends ZestAction {
+
+    private String globalVariableName;
+
+    public ZestActionGlobalVariableRemove() {
+        super();
+    }
+
+    public ZestActionGlobalVariableRemove(String globalVariableName) {
+        super();
+        this.globalVariableName = globalVariableName;
+    }
+
+    /**
+     * Gets the name of the global variable.
+     *
+     * @return the name of the global variable, might be {@code null}.
+     */
+    public String getGlobalVariableName() {
+        return globalVariableName;
+    }
+
+    /**
+     * Sets the name of the global variable.
+     *
+     * @param globalVariableName the name of the global variable.
+     */
+    public void setGlobalVariableName(String globalVariableName) {
+        this.globalVariableName = globalVariableName;
+    }
+
+    @Override
+    public String invoke(ZestResponse response, ZestRuntime runtime)
+            throws ZestActionFailException {
+        runtime.setGlobalVariable(globalVariableName, null);
+        return null;
+    }
+
+    @Override
+    public boolean isPassive() {
+        return true;
+    }
+
+    @Override
+    public ZestStatement deepCopy() {
+        ZestActionGlobalVariableRemove copy =
+                new ZestActionGlobalVariableRemove(globalVariableName);
+        copy.setEnabled(isEnabled());
+        return copy;
+    }
+}

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionGlobalVariableSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionGlobalVariableSet.java
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.zest.core.v1;
+
+/**
+ * A {@link ZestAction} that sets the value of a {@link ZestRuntime#setGlobalVariable(String,
+ * String) global variable}.
+ *
+ * <p>The value might reference script variables which are replaced before setting it.
+ *
+ * @since 0.14.0
+ * @see ZestAssignGlobalVariable
+ * @see ZestActionGlobalVariableRemove
+ */
+public class ZestActionGlobalVariableSet extends ZestAction {
+
+    private String globalVariableName;
+    private String value;
+
+    public ZestActionGlobalVariableSet() {
+        super();
+    }
+
+    public ZestActionGlobalVariableSet(String globalVariableName, String value) {
+        super();
+        this.globalVariableName = globalVariableName;
+        this.value = value;
+    }
+
+    /**
+     * Gets the name of the global variable.
+     *
+     * @return the name of the global variable, might be {@code null}.
+     */
+    public String getGlobalVariableName() {
+        return globalVariableName;
+    }
+
+    /**
+     * Sets the name of the global variable.
+     *
+     * @param globalVariableName the name of the global variable.
+     */
+    public void setGlobalVariableName(String globalVariableName) {
+        this.globalVariableName = globalVariableName;
+    }
+
+    /**
+     * Gets the value for the global variable.
+     *
+     * @return the value for the global variable, might be {@code null}.
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Sets the value for the global variable.
+     *
+     * @param value the value for the global variable.
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String invoke(ZestResponse response, ZestRuntime runtime)
+            throws ZestActionFailException {
+        String replacedValue = runtime.replaceVariablesInString(value, false);
+        runtime.setGlobalVariable(globalVariableName, replacedValue);
+        return replacedValue;
+    }
+
+    @Override
+    public boolean isPassive() {
+        return true;
+    }
+
+    @Override
+    public ZestStatement deepCopy() {
+        ZestActionGlobalVariableSet copy =
+                new ZestActionGlobalVariableSet(globalVariableName, value);
+        copy.setEnabled(isEnabled());
+        return copy;
+    }
+}

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignGlobalVariable.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignGlobalVariable.java
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.zest.core.v1;
+
+/**
+ * A {@link ZestAssignment} from a {@link ZestRuntime#getGlobalVariable(String) global variable}.
+ *
+ * @since 0.14.0
+ * @see ZestActionGlobalVariableRemove
+ * @see ZestActionGlobalVariableSet
+ */
+public class ZestAssignGlobalVariable extends ZestAssignment {
+
+    private String globalVariableName;
+
+    /**
+     * Constructs a {@code ZestAssignGlobalVariable} with no target variable nor global variable.
+     */
+    public ZestAssignGlobalVariable() {}
+
+    /**
+     * Constructs a {@code ZestAssignGlobalVariable} with the given target variable.
+     *
+     * @param variableName the name of the variable where to assign the global variable, might be
+     *     {@code null}.
+     */
+    public ZestAssignGlobalVariable(String variableName) {
+        super(variableName);
+    }
+
+    /**
+     * Constructs a {@code ZestAssignGlobalVariable} with the given target variable and global
+     * variable.
+     *
+     * @param variableName the name of the variable where to assign the global variable, might be
+     *     {@code null}.
+     * @param globalVariableName the name of the global variable, might be {@code null}.
+     */
+    public ZestAssignGlobalVariable(String variableName, String globalVariableName) {
+        super(variableName);
+        this.globalVariableName = globalVariableName;
+    }
+
+    /**
+     * Gets the name of the global variable.
+     *
+     * @return the name of the global variable, might be {@code null}.
+     */
+    public String getGlobalVariableName() {
+        return globalVariableName;
+    }
+
+    /**
+     * Sets the name of the global variable.
+     *
+     * @param globalVariableName the name of the global variable.
+     */
+    public void setGlobalVariableName(String globalVariableName) {
+        this.globalVariableName = globalVariableName;
+    }
+
+    @Override
+    public String assign(ZestResponse response, ZestRuntime runtime) {
+        return runtime.getGlobalVariable(globalVariableName);
+    }
+
+    @Override
+    public ZestAssignGlobalVariable deepCopy() {
+        ZestAssignGlobalVariable copy =
+                new ZestAssignGlobalVariable(this.getVariableName(), this.globalVariableName);
+        copy.setEnabled(this.isEnabled());
+        return copy;
+    }
+}

--- a/src/main/java/org/mozilla/zest/core/v1/ZestRuntime.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestRuntime.java
@@ -27,6 +27,35 @@ public interface ZestRuntime extends ZestOutputWriter {
     void setVariable(String name, String value);
 
     /**
+     * Gets a global variable.
+     *
+     * <p>The global variables should outlive and be available to all scripts. How and where the
+     * variables are persisted and for how long is left as an implementation detail.
+     *
+     * @param name the name of the variable.
+     * @return the value of the variable, might be {@code null} if no value was previously set.
+     * @since 0.14.0
+     * @see #setGlobalVariable(String, String)
+     */
+    default String getGlobalVariable(String name) {
+        return null;
+    }
+
+    /**
+     * Sets or removes a global variable.
+     *
+     * <p>The variable is removed when the {@code value} is {@code null}.
+     *
+     * @param name the name of the variable.
+     * @param value the value of the variable.
+     * @since 0.14.0
+     * @see #getGlobalVariable(String)
+     */
+    default void setGlobalVariable(String name, String value) {
+        // Nothing to do.
+    }
+
+    /**
      * Get the last response.
      *
      * @return the last response


### PR DESCRIPTION
Add action statements to set and remove global variables.
Add assign statement from a global variable.
Change ZestRuntime to allow to set/get global variables.

Related to zaproxy/zaproxy#3512 - Allow to set/get global variables