### PR TITLE
Add missing test annotations

### DIFF
--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionResponseTimeUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionResponseTimeUnitTest.java
@@ -76,6 +76,7 @@ public class ZestExpressionResponseTimeUnitTest {
         assertTrue(timeExpr.getTimeInMs() != copy.getTimeInMs());
     }
 
+    @Test
     public void testIsTrueDeepCopyDifferentGreaterThan() {
         ZestExpressionResponseTime timeExpr = new ZestExpressionResponseTime(1000);
         ZestExpressionResponseTime copy = timeExpr.deepCopy();

--- a/src/test/java/org/mozilla/zest/test/v1/ZestStructuredExpressionUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestStructuredExpressionUnitTest.java
@@ -38,6 +38,7 @@ public class ZestStructuredExpressionUnitTest {
         assertTrue(and.getChildrenCondition().size() == copy.getChildrenCondition().size());
     }
 
+    @Test
     public void testOrDeepCopySingleAndSameChildrenSize() {
         ZestExpressionOr or = new ZestExpressionOr();
         or.addChildCondition(new ZestExpressionStatusCode(100));


### PR DESCRIPTION
Add the annotation to tests in `ZestExpressionResponseTimeUnitTest` and
`ZestStructuredExpressionUnitTest`.
Thanks to Error Prone.