### PR TITLE
Keep proxying localhost with launched browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Accept insecure certs when launching browsers. [#136](https://github.com/mozilla/zest/pull/136)
 - Update HTTP client implementation, use HttpComponents Client instead of Commons HttpClient. [#168](https://github.com/mozilla/zest/issues/168)
 - Update Selenium to 3.14.0. [#169](https://github.com/mozilla/zest/issues/169)
+- Keep proxying localhost with Chrome 72+ and Firefox 67+. [#197](https://github.com/mozilla/zest/pull/197)
 
 ### Removed
 - Remove dependency on Commons HttpClient, the client implementation, and related methods. [#136](https://github.com/mozilla/zest/pull/136)

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientLaunch.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientLaunch.java
@@ -216,6 +216,8 @@ public class ZestClientLaunch extends ZestClient {
                     firefoxOptions.addPreference("network.proxy.no_proxies_on", "");
                     // And remove the PROXY capability:
                     cap.setCapability(CapabilityType.PROXY, (Object) null);
+
+                    firefoxOptions.addPreference("network.proxy.allow_hijacking_localhost", true);
                 }
                 firefoxOptions.merge(cap);
 
@@ -230,6 +232,10 @@ public class ZestClientLaunch extends ZestClient {
                     chromeOptions.addArguments("user-data-dir=" + userDataDir);
                     chromeOptions.addArguments("--profile-directory=" + profileDirName);
                 }
+                if (!httpProxy.isEmpty()) {
+                    chromeOptions.addArguments("--proxy-bypass-list=<-loopback>");
+                }
+
                 chromeOptions.merge(cap);
 
                 driver = new ChromeDriver(chromeOptions);


### PR DESCRIPTION
Change `ZestClientLaunch` to proxy localhost also with newer versions of
Chrome (72+) and Firefox (67+).