### PR TITLE
Use just OpenJDK in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ cache:
     - $HOME/.gradle/wrapper/
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11


### PR DESCRIPTION
Replace OracleJDK with OpenJDK, the former is no longer included by
default in newer dists (Xenial).