### PR TITLE
Update Selenium to 3.141.59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change action invoke to allow to set the charset. [#134](https://github.com/mozilla/zest/pull/134)
 - Accept insecure certs when launching browsers. [#136](https://github.com/mozilla/zest/pull/136)
 - Update HTTP client implementation, use HttpComponents Client instead of Commons HttpClient. [#168](https://github.com/mozilla/zest/issues/168)
-- Update Selenium to 3.14.0. [#169](https://github.com/mozilla/zest/issues/169)
+- Update Selenium to 3.141.59. [#169](https://github.com/mozilla/zest/issues/169)
 - Keep proxying localhost with Chrome 72+ and Firefox 67+. [#197](https://github.com/mozilla/zest/pull/197)
 
 ### Removed

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,8 @@ dependencies {
              'com.google.code.gson:gson:2.8.5',
              'com.opera:operadriver:1.5',
              'com.codeborne:phantomjsdriver:1.4.3',
-             'org.seleniumhq.selenium:selenium-server:3.14.0',
+             'org.seleniumhq.selenium:selenium-server:3.141.59',
+             'org.seleniumhq.selenium:htmlunit-driver:2.36.0',
              'net.htmlparser.jericho:jericho-html:3.1')
 
     implementation('com.machinepublishers:jbrowserdriver:1.0.0-RC1') {


### PR DESCRIPTION
Update Selenium to latest version.
Add dependency on `htmlunit-driver`, no longer included in the other
library.