### PR TITLE
Tidy up Java code

### DIFF
--- a/src/main/java/org/mozilla/zest/core/v1/ZestAction.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAction.java
@@ -3,8 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
-import java.net.MalformedURLException;
-
 // TODO: Auto-generated Javadoc
 /** The Class ZestAction. */
 public abstract class ZestAction extends ZestStatement {
@@ -29,7 +27,7 @@ public abstract class ZestAction extends ZestStatement {
     }
 
     @Override
-    void setPrefix(String oldPrefix, String newPrefix) throws MalformedURLException {
+    void setPrefix(String oldPrefix, String newPrefix) {
         // Ignore
     }
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionFail.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionFail.java
@@ -13,7 +13,7 @@ public class ZestActionFail extends ZestAction {
         LOW,
         MEDIUM,
         HIGH
-    };
+    }
 
     /** The message. */
     private String message;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionGlobalVariableRemove.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionGlobalVariableRemove.java
@@ -43,8 +43,7 @@ public class ZestActionGlobalVariableRemove extends ZestAction {
     }
 
     @Override
-    public String invoke(ZestResponse response, ZestRuntime runtime)
-            throws ZestActionFailException {
+    public String invoke(ZestResponse response, ZestRuntime runtime) {
         runtime.setGlobalVariable(globalVariableName, null);
         return null;
     }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionGlobalVariableSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionGlobalVariableSet.java
@@ -65,8 +65,7 @@ public class ZestActionGlobalVariableSet extends ZestAction {
     }
 
     @Override
-    public String invoke(ZestResponse response, ZestRuntime runtime)
-            throws ZestActionFailException {
+    public String invoke(ZestResponse response, ZestRuntime runtime) {
         String replacedValue = runtime.replaceVariablesInString(value, false);
         runtime.setGlobalVariable(globalVariableName, replacedValue);
         return replacedValue;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionIntercept.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionIntercept.java
@@ -31,8 +31,7 @@ public class ZestActionIntercept extends ZestAction {
     }
 
     @Override
-    public String invoke(ZestResponse response, ZestRuntime runtime)
-            throws ZestActionFailException {
+    public String invoke(ZestResponse response, ZestRuntime runtime) {
         // Ignore
         return "";
     }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionInvoke.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionInvoke.java
@@ -24,7 +24,7 @@ public class ZestActionInvoke extends ZestAction {
     /** The path to the script - can be relative or absolute. */
     private String script;
 
-    private List<String[]> parameters = new ArrayList<String[]>();
+    private List<String[]> parameters = new ArrayList<>();
 
     /**
      * The name of the charset used for read operations (for example, read the script or the output
@@ -251,7 +251,7 @@ public class ZestActionInvoke extends ZestAction {
         ZestActionInvoke copy = new ZestActionInvoke(this.getIndex());
         copy.script = script;
         copy.variableName = variableName;
-        copy.parameters = new ArrayList<String[]>();
+        copy.parameters = new ArrayList<>();
         for (String[] kvPair : this.parameters) {
             copy.parameters.add(new String[] {kvPair[0], kvPair[1]});
         }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionPrint.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionPrint.java
@@ -39,8 +39,7 @@ public class ZestActionPrint extends ZestAction {
     }
 
     @Override
-    public String invoke(ZestResponse response, ZestRuntime runtime)
-            throws ZestActionFailException {
+    public String invoke(ZestResponse response, ZestRuntime runtime) {
         String str = runtime.replaceVariablesInString(this.message, false);
         runtime.output(str);
         return str;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignRandomInteger.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignRandomInteger.java
@@ -44,8 +44,7 @@ public class ZestAssignRandomInteger extends ZestAssignment {
     }
 
     @Override
-    public String assign(ZestResponse response, ZestRuntime runtime)
-            throws ZestAssignFailException {
+    public String assign(ZestResponse response, ZestRuntime runtime) {
         int val = minInt + rnd.nextInt(maxInt - minInt);
         return Integer.toString(val);
     }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignRegexDelimiters.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignRegexDelimiters.java
@@ -39,7 +39,7 @@ public class ZestAssignRegexDelimiters extends ZestAssignment {
 
     /** The Constant LOCATIONS. */
     private static final transient Set<String> LOCATIONS =
-            new HashSet<String>(Arrays.asList(new String[] {LOC_HEAD, LOC_BODY}));
+            new HashSet<>(Arrays.asList(LOC_HEAD, LOC_BODY));
 
     /** Instantiates a new zest action set token. */
     public ZestAssignRegexDelimiters() {

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignStringDelimiters.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignStringDelimiters.java
@@ -31,7 +31,7 @@ public class ZestAssignStringDelimiters extends ZestAssignment {
 
     /** The set of valid locations. */
     private static final transient Set<String> LOCATIONS =
-            new HashSet<String>(Arrays.asList(new String[] {LOC_HEAD, LOC_BODY}));
+            new HashSet<>(Arrays.asList(LOC_HEAD, LOC_BODY));
 
     /** Instantiates a new zest action set variable. */
     public ZestAssignStringDelimiters() {

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignment.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignment.java
@@ -3,8 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
-import java.net.MalformedURLException;
-
 // TODO: Auto-generated Javadoc
 /** The Class ZestAction. */
 public abstract class ZestAssignment extends ZestStatement {
@@ -42,7 +40,7 @@ public abstract class ZestAssignment extends ZestStatement {
     }
 
     @Override
-    void setPrefix(String oldPrefix, String newPrefix) throws MalformedURLException {
+    void setPrefix(String oldPrefix, String newPrefix) {
         // Ignore
     }
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClient.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClient.java
@@ -3,8 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
-import java.net.MalformedURLException;
-
 /** An abstract class that all client related statements extend. */
 public abstract class ZestClient extends ZestStatement {
 
@@ -30,7 +28,7 @@ public abstract class ZestClient extends ZestStatement {
     }
 
     @Override
-    void setPrefix(String oldPrefix, String newPrefix) throws MalformedURLException {
+    void setPrefix(String oldPrefix, String newPrefix) {
         // Ignore
     }
 }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientAssignCookie.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientAssignCookie.java
@@ -53,7 +53,7 @@ public class ZestClientAssignCookie extends ZestClient {
     }
 
     @Override
-    public String invoke(ZestRuntime runtime) throws ZestClientFailException {
+    public String invoke(ZestRuntime runtime) {
         WebDriver wd = runtime.getWebDriver(this.getWindowHandle());
         String val = "";
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientWindowClose.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientWindowClose.java
@@ -55,7 +55,7 @@ public class ZestClientWindowClose extends ZestClient {
     }
 
     @Override
-    public String invoke(ZestRuntime runtime) throws ZestClientFailException {
+    public String invoke(ZestRuntime runtime) {
         WebDriver wd = runtime.getWebDriver(this.getWindowHandle());
 
         if (wd == null) {

--- a/src/main/java/org/mozilla/zest/core/v1/ZestComment.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestComment.java
@@ -3,8 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
-import java.net.MalformedURLException;
-
 /** Exits the script returning a string. */
 public class ZestComment extends ZestStatement {
 
@@ -21,7 +19,7 @@ public class ZestComment extends ZestStatement {
     }
 
     @Override
-    void setPrefix(String oldPrefix, String newPrefix) throws MalformedURLException {}
+    void setPrefix(String oldPrefix, String newPrefix) {}
 
     @Override
     public ZestComment deepCopy() {

--- a/src/main/java/org/mozilla/zest/core/v1/ZestConditional.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestConditional.java
@@ -17,10 +17,10 @@ public class ZestConditional extends ZestStatement implements ZestContainer {
     private ZestExpressionElement rootExpression = null;
 
     /** The if statements. */
-    private List<ZestStatement> ifStatements = new ArrayList<ZestStatement>();
+    private List<ZestStatement> ifStatements = new ArrayList<>();
 
     /** The else statements. */
-    private List<ZestStatement> elseStatements = new ArrayList<ZestStatement>();
+    private List<ZestStatement> elseStatements = new ArrayList<>();
 
     /** Instantiates a new zest conditional. */
     public ZestConditional() {
@@ -128,7 +128,7 @@ public class ZestConditional extends ZestStatement implements ZestContainer {
      * @return the if statement at index
      * @throws IndexOutOfBoundsException the index out of bounds exception
      */
-    public ZestStatement getIfStatement(int index) throws IndexOutOfBoundsException {
+    public ZestStatement getIfStatement(int index) {
         return this.ifStatements.get(index);
     }
 
@@ -152,7 +152,7 @@ public class ZestConditional extends ZestStatement implements ZestContainer {
 
     @Override
     public List<ZestStatement> getChildren() {
-        List<ZestStatement> children = new ArrayList<ZestStatement>();
+        List<ZestStatement> children = new ArrayList<>();
         children.addAll(this.getIfStatements());
         children.addAll(this.getElseStatements());
         return Collections.unmodifiableList(children);
@@ -225,7 +225,7 @@ public class ZestConditional extends ZestStatement implements ZestContainer {
      * @return the else statement at the given index
      * @throws IndexOutOfBoundsException the index out of bounds exception
      */
-    public ZestStatement getElseStatement(int index) throws IndexOutOfBoundsException {
+    public ZestStatement getElseStatement(int index) {
         return this.elseStatements.get(index);
     }
 
@@ -276,7 +276,7 @@ public class ZestConditional extends ZestStatement implements ZestContainer {
 
     @Override
     public Set<String> getVariableNames() {
-        Set<String> tokens = new HashSet<String>();
+        Set<String> tokens = new HashSet<>();
 
         for (ZestStatement stmt : this.ifStatements) {
             if (stmt instanceof ZestContainer) {

--- a/src/main/java/org/mozilla/zest/core/v1/ZestContainer.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestContainer.java
@@ -15,7 +15,7 @@ public interface ZestContainer {
      *
      * @return the last
      */
-    public ZestStatement getLast();
+    ZestStatement getLast();
 
     /**
      * Gets the statement.
@@ -23,7 +23,7 @@ public interface ZestContainer {
      * @param index the index
      * @return the statement
      */
-    public ZestStatement getStatement(int index);
+    ZestStatement getStatement(int index);
 
     /**
      * Gets the index.
@@ -31,7 +31,7 @@ public interface ZestContainer {
      * @param child the child
      * @return the index
      */
-    public int getIndex(ZestStatement child);
+    int getIndex(ZestStatement child);
 
     /**
      * Move.
@@ -39,7 +39,7 @@ public interface ZestContainer {
      * @param index the index
      * @param stmt the stmt
      */
-    public void move(int index, ZestStatement stmt);
+    void move(int index, ZestStatement stmt);
 
     /**
      * Gets the child before.
@@ -47,19 +47,19 @@ public interface ZestContainer {
      * @param child the child
      * @return the child before
      */
-    public ZestStatement getChildBefore(ZestStatement child);
+    ZestStatement getChildBefore(ZestStatement child);
 
     /**
      * Returns all of the containers immediate children
      *
      * @return the children
      */
-    public List<ZestStatement> getChildren();
+    List<ZestStatement> getChildren();
 
     /**
      * Returns all of the variable names defined by this staement and its children.
      *
      * @return the tokens
      */
-    abstract Set<String> getVariableNames();
+    Set<String> getVariableNames();
 }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestControl.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestControl.java
@@ -3,8 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
-import java.net.MalformedURLException;
-
 /** An abstract class representing statements that change the flow of statements */
 public abstract class ZestControl extends ZestStatement {
 
@@ -28,7 +26,7 @@ public abstract class ZestControl extends ZestStatement {
     }
 
     @Override
-    void setPrefix(String oldPrefix, String newPrefix) throws MalformedURLException {
+    void setPrefix(String oldPrefix, String newPrefix) {
         // Ignore
     }
 }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestControlLoopBreak.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestControlLoopBreak.java
@@ -3,15 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
-import java.net.MalformedURLException;
-
 // TODO: Auto-generated Javadoc
 
 /** empty class: represents a BREAK inside the loop. */
 public class ZestControlLoopBreak extends ZestControl {
 
     @Override
-    void setPrefix(String oldPrefix, String newPrefix) throws MalformedURLException {}
+    void setPrefix(String oldPrefix, String newPrefix) {}
 
     @Override
     public ZestControlLoopBreak deepCopy() {

--- a/src/main/java/org/mozilla/zest/core/v1/ZestControlLoopNext.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestControlLoopNext.java
@@ -3,15 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
-import java.net.MalformedURLException;
-
 // TODO: Auto-generated Javadoc
 
 /** This class represents a NEXT statement for a loop. */
 public class ZestControlLoopNext extends ZestControl {
 
     @Override
-    void setPrefix(String oldPrefix, String newPrefix) throws MalformedURLException {}
+    void setPrefix(String oldPrefix, String newPrefix) {}
 
     @Override
     public ZestControlLoopNext deepCopy() {

--- a/src/main/java/org/mozilla/zest/core/v1/ZestControlReturn.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestControlReturn.java
@@ -3,8 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
-import java.net.MalformedURLException;
-
 /** Exits the script returning a string. */
 public class ZestControlReturn extends ZestControl {
 
@@ -21,7 +19,7 @@ public class ZestControlReturn extends ZestControl {
     }
 
     @Override
-    void setPrefix(String oldPrefix, String newPrefix) throws MalformedURLException {}
+    void setPrefix(String oldPrefix, String newPrefix) {}
 
     @Override
     public ZestControlReturn deepCopy() {

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionAnd.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionAnd.java
@@ -46,14 +46,12 @@ public class ZestExpressionAnd extends ZestStructuredExpression {
         if (getChildrenCondition().isEmpty()) {
             return false;
         }
-        boolean toReturn = true;
         for (ZestExpressionElement con : getChildrenCondition()) {
-            toReturn = toReturn && con.evaluate(runtime); // compute AND for each child
-            if (!toReturn) {
-                break; // lazy evaluation
+            if (!con.evaluate(runtime)) {
+                return false; // lazy evaluation
             }
         }
-        return toReturn;
+        return true;
     }
 
     @Override

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionElement.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionElement.java
@@ -18,7 +18,7 @@ public interface ZestExpressionElement {
      *
      * @return true if it is a Simple Conditional false otherwise
      */
-    public boolean isLeaf();
+    boolean isLeaf();
 
     /**
      * the boolean value result of the expression without inverse flag.
@@ -26,7 +26,7 @@ public interface ZestExpressionElement {
      * @param runtime the runtime
      * @return the boolean value of the expression without inverse flag
      */
-    public boolean isTrue(ZestRuntime runtime);
+    boolean isTrue(ZestRuntime runtime);
 
     /**
      * the boolean value of the whole Conditional Element.
@@ -34,21 +34,21 @@ public interface ZestExpressionElement {
      * @param runtime the runtime
      * @return the boolean value of the whole Conditional Element
      */
-    public boolean evaluate(ZestRuntime runtime);
+    boolean evaluate(ZestRuntime runtime);
 
     /**
      * return true if the Conditional Element has a NOT clause.
      *
      * @return true if the Conditional Element has a NOT clause
      */
-    public boolean isInverse();
+    boolean isInverse();
 
     /**
      * sets if the Conditional Element has a NOT clause.
      *
      * @param not true if this Conditional Element has to contain the NOT clause
      */
-    public void setInverse(boolean not);
+    void setInverse(boolean not);
 
     /**
      * Deep copy.
@@ -56,5 +56,5 @@ public interface ZestExpressionElement {
      * @return a copy of the ZestConditionalElement
      * @see ZestElement
      */
-    public ZestExpressionElement deepCopy();
+    ZestExpressionElement deepCopy();
 }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionOr.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionOr.java
@@ -26,15 +26,12 @@ public class ZestExpressionOr extends ZestStructuredExpression {
 
     @Override
     public boolean isTrue(ZestRuntime runtime) {
-        boolean toReturn = false;
         for (ZestExpressionElement con : getChildrenCondition()) {
-            toReturn = toReturn || con.evaluate(runtime); // compute OR for each
-            // child
-            if (toReturn) {
-                break; // lazy evaluation
+            if (con.evaluate(runtime)) {
+                return true; // lazy evaluation
             }
         }
-        return toReturn;
+        return false;
     }
 
     @Override

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionURL.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionURL.java
@@ -11,10 +11,10 @@ import java.util.regex.Pattern;
 public class ZestExpressionURL extends ZestExpression {
 
     /** The include regexes. */
-    private List<String> includeRegexes = new ArrayList<String>();
+    private List<String> includeRegexes = new ArrayList<>();
 
     /** The exclude regexes. */
-    private List<String> excludeRegexes = new ArrayList<String>();
+    private List<String> excludeRegexes = new ArrayList<>();
 
     /** The include patterns. */
     private transient List<Pattern> includePatterns = null;
@@ -90,8 +90,8 @@ public class ZestExpressionURL extends ZestExpression {
     }
 
     private void initPatterns() {
-        includePatterns = new ArrayList<Pattern>();
-        excludePatterns = new ArrayList<Pattern>();
+        includePatterns = new ArrayList<>();
+        excludePatterns = new ArrayList<>();
 
         if (includeRegexes != null) {
             for (String regex : includeRegexes) {

--- a/src/main/java/org/mozilla/zest/core/v1/ZestJSON.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestJSON.java
@@ -72,8 +72,7 @@ public class ZestJSON implements JsonDeserializer<ZestElement>, JsonSerializer<Z
 
     @Override
     public ZestElement deserialize(
-            JsonElement element, Type rawType, JsonDeserializationContext arg2)
-            throws JsonParseException {
+            JsonElement element, Type rawType, JsonDeserializationContext arg2) {
         if (element instanceof JsonObject) {
             String elementType = ((JsonObject) element).get("elementType").getAsString();
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoop.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoop.java
@@ -260,7 +260,7 @@ public abstract class ZestLoop<T> extends ZestStatement
 
     @Override
     public Set<String> getVariableNames() {
-        Set<String> tokens = new HashSet<String>();
+        Set<String> tokens = new HashSet<>();
         tokens.add(this.getVariableName());
         for (ZestStatement stmt : this.statements) {
             if (stmt instanceof ZestContainer) {

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopClientElements.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopClientElements.java
@@ -3,10 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-
-/** This class represent a loop through a list of strings given in input through a file. */
+/** This class represent a loop through a set of client elements */
 public class ZestLoopClientElements extends ZestLoop<String> {
 
     private ZestLoopTokenClientElementsSet set = null;
@@ -21,22 +18,15 @@ public class ZestLoopClientElements extends ZestLoop<String> {
         this.set = new ZestLoopTokenClientElementsSet(this, windowHandle, type, element, attribute);
     }
 
-    /**
-     * Instantiates a new zest loop file.
-     *
-     * @throws FileNotFoundException the file not found exception
-     * @throws IOException Signals that an I/O exception has occurred.
-     */
+    /** Instantiates a new loop of client elements. */
     public ZestLoopClientElements() {
         this.set = new ZestLoopTokenClientElementsSet(this, "", "", "", "");
     }
 
     /**
-     * Instantiates a new zest loop file.
+     * Instantiates a new loop of client elements.
      *
      * @param index the index of the statement
-     * @throws IOException
-     * @throws FileNotFoundException
      */
     private ZestLoopClientElements(int index) {
         super(index);

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopFile.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopFile.java
@@ -19,7 +19,7 @@ public class ZestLoopFile extends ZestLoop<String> {
      * @throws FileNotFoundException the file not found exception
      * @throws IOException Signals that an I/O exception has occurred.
      */
-    public ZestLoopFile() throws FileNotFoundException, IOException {
+    public ZestLoopFile() throws IOException {
         this(File.createTempFile("emptyfile", ".txt"));
     }
 
@@ -27,10 +27,9 @@ public class ZestLoopFile extends ZestLoop<String> {
      * Instantiates a new zest loop file.
      *
      * @param index the index of the statement
-     * @throws IOException
-     * @throws FileNotFoundException
+     * @throws IOException if an I/O error occurred.
      */
-    private ZestLoopFile(int index) throws FileNotFoundException, IOException {
+    private ZestLoopFile(int index) throws IOException {
         super(index);
         this.set =
                 new ZestLoopTokenFileSet(

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopRegex.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopRegex.java
@@ -49,7 +49,7 @@ public class ZestLoopRegex extends ZestLoop<String> {
     }
 
     @Override
-    public ZestLoopState<String> getCurrentState() {
+    public ZestLoopStateRegex getCurrentState() {
         return (ZestLoopStateRegex) super.getCurrentState();
     }
 

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateRegex.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateRegex.java
@@ -11,7 +11,7 @@ public class ZestLoopStateRegex extends ZestLoopStateString {
         super();
     }
 
-    public ZestLoopStateRegex(ZestLoopTokenRegexSet set) throws ZestClientFailException {
+    public ZestLoopStateRegex(ZestLoopTokenRegexSet set) {
         super(set.getConvertedSet());
     }
 }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenRegexSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenRegexSet.java
@@ -56,9 +56,8 @@ public class ZestLoopTokenRegexSet extends ZestElement implements ZestLoopTokenS
      * private method for initialization of the loop (TokenSet &amp; first state).
      *
      * @return the zest loop token string set
-     * @throws ZestClientFailException
      */
-    protected ZestLoopTokenStringSet getConvertedSet() throws ZestClientFailException {
+    protected ZestLoopTokenStringSet getConvertedSet() {
         if (this.convertedSet == null) {
             if (loop == null) {
                 // Not yet initialized
@@ -94,46 +93,26 @@ public class ZestLoopTokenRegexSet extends ZestElement implements ZestLoopTokenS
 
     @Override
     public String getToken(int index) {
-        try {
-            return this.getConvertedSet().getToken(index);
-        } catch (ZestClientFailException e) {
-            return null;
-        }
+        return this.getConvertedSet().getToken(index);
     }
 
     public List<String> getTokens() {
-        try {
-            return Collections.unmodifiableList(getConvertedSet().getTokens());
-        } catch (ZestClientFailException e) {
-            return null;
-        }
+        return Collections.unmodifiableList(getConvertedSet().getTokens());
     }
 
     @Override
     public int indexOf(String token) {
-        try {
-            return getConvertedSet().indexOf(token);
-        } catch (ZestClientFailException e) {
-            return -1;
-        }
+        return getConvertedSet().indexOf(token);
     }
 
     @Override
     public String getLastToken() {
-        try {
-            return getConvertedSet().getLastToken();
-        } catch (ZestClientFailException e) {
-            return null;
-        }
+        return getConvertedSet().getLastToken();
     }
 
     @Override
     public int size() {
-        try {
-            return this.getConvertedSet().size();
-        } catch (ZestClientFailException e) {
-            return -1;
-        }
+        return this.getConvertedSet().size();
     }
 
     @Override
@@ -187,10 +166,6 @@ public class ZestLoopTokenRegexSet extends ZestElement implements ZestLoopTokenS
 
     @Override
     public ZestLoopStateRegex getFirstState() {
-        try {
-            return new ZestLoopStateRegex(this);
-        } catch (ZestClientFailException e) {
-            return null;
-        }
+        return new ZestLoopStateRegex(this);
     }
 }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenSet.java
@@ -17,7 +17,7 @@ public interface ZestLoopTokenSet<T> {
      * @param index the index of the token
      * @return the token at the given index
      */
-    public T getToken(int index);
+    T getToken(int index);
 
     /**
      * returns the index of a given token.
@@ -25,33 +25,33 @@ public interface ZestLoopTokenSet<T> {
      * @param token the token whose index we are searching for
      * @return the index of the token
      */
-    public int indexOf(T token);
+    int indexOf(T token);
 
     /**
      * returns the last token the loop may consider.
      *
      * @return the last token the loop may consider
      */
-    public T getLastToken();
+    T getLastToken();
 
     /**
      * returns the size of this set.
      *
      * @return the size of this set
      */
-    public int size();
+    int size();
 
     /**
      * Deep copy.
      *
      * @return the zest loop token set
      */
-    public ZestLoopTokenSet<T> deepCopy();
+    ZestLoopTokenSet<T> deepCopy();
 
     /**
      * Gets the first state.
      *
      * @return the first state
      */
-    public ZestLoopState<T> getFirstState();
+    ZestLoopState<T> getFirstState();
 }

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenStringSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenStringSet.java
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -36,9 +37,7 @@ public class ZestLoopTokenStringSet extends ZestElement implements ZestLoopToken
     public ZestLoopTokenStringSet(String[] values) {
         super();
         tokens = new LinkedList<>();
-        for (String value : values) {
-            tokens.add(value);
-        }
+        Collections.addAll(tokens, values);
     }
 
     public void addToken(String token) {

--- a/src/main/java/org/mozilla/zest/core/v1/ZestRequest.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestRequest.java
@@ -32,7 +32,7 @@ public class ZestRequest extends ZestStatement {
     private ZestResponse response;
 
     /** The assertions. */
-    private List<ZestAssertion> assertions = new ArrayList<ZestAssertion>();
+    private List<ZestAssertion> assertions = new ArrayList<>();
 
     /** If true follow redirects, otherwise do not */
     private boolean followRedirects = true;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestScript.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestScript.java
@@ -89,10 +89,10 @@ public class ZestScript extends ZestStatement implements ZestContainer {
     private ZestVariables parameters = new ZestVariables();
 
     /** The statements. */
-    private List<ZestStatement> statements = new ArrayList<ZestStatement>();
+    private List<ZestStatement> statements = new ArrayList<>();
 
     /** The authentication. */
-    private List<ZestAuthentication> authentication = new ArrayList<ZestAuthentication>();
+    private List<ZestAuthentication> authentication = new ArrayList<>();
 
     /** Instantiates a new zest script. */
     public ZestScript() {
@@ -503,7 +503,7 @@ public class ZestScript extends ZestStatement implements ZestContainer {
 
     @Override
     public Set<String> getVariableNames() {
-        Set<String> tokens = new HashSet<String>();
+        Set<String> tokens = new HashSet<>();
 
         // Add the 'standard' ones
         tokens.add(ZestVariables.REQUEST_URL);
@@ -542,7 +542,7 @@ public class ZestScript extends ZestStatement implements ZestContainer {
      * @return the window handles.
      */
     public Set<String> getClientWindowHandles() {
-        Set<String> ids = new HashSet<String>();
+        Set<String> ids = new HashSet<>();
         ZestStatement next = this.getNext();
         while (next != null) {
             if (next instanceof ZestClientLaunch) {

--- a/src/main/java/org/mozilla/zest/core/v1/ZestVariables.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestVariables.java
@@ -123,7 +123,7 @@ public class ZestVariables extends ZestElement {
      * @return the tokens
      */
     public List<String[]> getVariables() {
-        List<String[]> list = new ArrayList<String[]>();
+        List<String[]> list = new ArrayList<>();
         for (Entry<String, String> entry : tokens.entrySet()) {
             list.add(new String[] {entry.getKey(), entry.getValue()});
         }
@@ -232,7 +232,7 @@ public class ZestVariables extends ZestElement {
     }
 
     public String replaceInString(String str, boolean urlEncode) {
-        List<String> prev = new ArrayList<String>();
+        List<String> prev = new ArrayList<>();
         return this.replaceInString(str, urlEncode, prev);
     }
 }

--- a/src/main/java/org/mozilla/zest/impl/CmdLine.java
+++ b/src/main/java/org/mozilla/zest/impl/CmdLine.java
@@ -43,7 +43,7 @@ public class CmdLine {
         File script = null;
         Mode mode = null;
         String prefix = null;
-        Map<String, String> tokens = new HashMap<String, String>();
+        Map<String, String> tokens = new HashMap<>();
         String httpAuthSite = null;
         String httpAuthRealm = null;
         String httpAuthUser = null;
@@ -194,7 +194,7 @@ public class CmdLine {
                 }
 
                 if (httpAuthSite != null) {
-                    List<ZestAuthentication> authList = new ArrayList<ZestAuthentication>();
+                    List<ZestAuthentication> authList = new ArrayList<>();
                     authList.add(
                             new ZestHttpAuthentication(
                                     httpAuthSite, httpAuthRealm, httpAuthUser, httpAuthPassword));

--- a/src/main/java/org/mozilla/zest/impl/ZestBasicRunner.java
+++ b/src/main/java/org/mozilla/zest/impl/ZestBasicRunner.java
@@ -64,7 +64,7 @@ public class ZestBasicRunner implements ZestRunner, ZestRuntime {
     private Stack<ZestLoop<?>> loops = new Stack<>();
     private boolean skipStatements = false;
 
-    private Map<String, WebDriver> webDriverMap = new HashMap<String, WebDriver>();
+    private Map<String, WebDriver> webDriverMap = new HashMap<>();
 
     /**
      * New Zest basic runner with default settings.
@@ -294,22 +294,12 @@ public class ZestBasicRunner implements ZestRunner, ZestRuntime {
             }
             this.setVariable(loop.getVariableName(), "");
             return lastResponse;
-        } catch (ZestAssertFailException e) {
-            this.output(e.getMessage());
-            throw e;
-        } catch (ZestActionFailException e) {
-            this.output(e.getMessage());
-            throw e;
-        } catch (ZestInvalidCommonTestException e) {
-            this.output(e.getMessage());
-            throw e;
-        } catch (IOException e) {
-            this.output(e.getMessage());
-            throw e;
-        } catch (ZestAssignFailException e) {
-            this.output(e.getMessage());
-            throw e;
-        } catch (ZestClientFailException e) {
+        } catch (ZestAssertFailException
+                | ZestActionFailException
+                | ZestInvalidCommonTestException
+                | IOException
+                | ZestAssignFailException
+                | ZestClientFailException e) {
             this.output(e.getMessage());
             throw e;
         }
@@ -376,7 +366,7 @@ public class ZestBasicRunner implements ZestRunner, ZestRuntime {
 
     @Override
     public void handleResponse(ZestRequest request, ZestResponse response)
-            throws ZestAssertFailException, ZestActionFailException {
+            throws ZestAssertFailException {
         boolean passed = true;
         for (ZestAssertion za : request.getAssertions()) {
             if (za.isValid(this)) {
@@ -415,8 +405,7 @@ public class ZestBasicRunner implements ZestRunner, ZestRuntime {
     }
 
     @Override
-    public void responseFailed(ZestRequest request, ZestResponse response)
-            throws ZestAssertFailException {
+    public void responseFailed(ZestRequest request, ZestResponse response) {
         this.debug(request.getIndex() + " Response FAILED");
     }
 
@@ -602,7 +591,7 @@ public class ZestBasicRunner implements ZestRunner, ZestRuntime {
 
     @Override
     public List<WebDriver> getWebDrivers() {
-        List<WebDriver> list = new ArrayList<WebDriver>();
+        List<WebDriver> list = new ArrayList<>();
         for (WebDriver wd : this.webDriverMap.values()) {
             list.add(wd);
         }

--- a/src/main/java/org/mozilla/zest/impl/ZestScriptEngine.java
+++ b/src/main/java/org/mozilla/zest/impl/ZestScriptEngine.java
@@ -27,7 +27,7 @@ public class ZestScriptEngine extends AbstractScriptEngine {
 
     @Override
     public Object eval(String script, ScriptContext context) throws ScriptException {
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
 
         if (context != null) {
             this.runner.setOutputWriter(context.getWriter());
@@ -50,7 +50,7 @@ public class ZestScriptEngine extends AbstractScriptEngine {
 
     @Override
     public Object eval(Reader reader, ScriptContext context) throws ScriptException {
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
 
         if (context != null) {
             this.runner.setOutputWriter(context.getWriter());

--- a/src/main/java/org/mozilla/zest/impl/ZestScriptEngineFactory.java
+++ b/src/main/java/org/mozilla/zest/impl/ZestScriptEngineFactory.java
@@ -39,7 +39,7 @@ public class ZestScriptEngineFactory implements ScriptEngineFactory {
 
     @Override
     public List<String> getExtensions() {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         list.add("zest");
         list.add("zst");
         return Collections.unmodifiableList(list);
@@ -53,7 +53,7 @@ public class ZestScriptEngineFactory implements ScriptEngineFactory {
 
     @Override
     public List<String> getNames() {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         list.add("Zest");
         return Collections.unmodifiableList(list);
     }

--- a/src/main/java/org/mozilla/zest/impl/ZestUtils.java
+++ b/src/main/java/org/mozilla/zest/impl/ZestUtils.java
@@ -13,7 +13,7 @@ import org.mozilla.zest.core.v1.ZestResponse;
 public class ZestUtils {
 
     public static List<String> getForms(ZestResponse response) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         Source src = new Source(response.getHeaders() + response.getBody());
         List<Element> formElements = src.getAllElements(HTMLElementName.FORM);
         int formId = 0;
@@ -28,7 +28,7 @@ public class ZestUtils {
     }
 
     public static List<String> getFields(ZestResponse response, int formId) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
 
         Source src = new Source(response.getHeaders() + response.getBody());
         List<Element> formElements = src.getAllElements(HTMLElementName.FORM);

--- a/src/test/java/org/mozilla/zest/test/v1/ZestActionInvokeUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestActionInvokeUnitTest.java
@@ -19,7 +19,7 @@ import org.mozilla.zest.core.v1.ZestResponse;
 public class ZestActionInvokeUnitTest {
 
     @Test
-    public void shouldUseArgsPassedInConstructor() throws Exception {
+    public void shouldUseArgsPassedInConstructor() {
         // Given
         String script = "script.js";
         String variable = "var";
@@ -34,11 +34,6 @@ public class ZestActionInvokeUnitTest {
         assertEquals(invokeAction.getCharset(), charset);
     }
 
-    /**
-     * Method testSimpleJsScript.
-     *
-     * @throws Exception
-     */
     @Test
     public void testSimpleJsScript() throws Exception {
         ZestActionInvoke inv = new ZestActionInvoke();
@@ -55,11 +50,6 @@ public class ZestActionInvokeUnitTest {
         assertEquals("abcde", result);
     }
 
-    /**
-     * Method testSimpleJsScript.
-     *
-     * @throws Exception
-     */
     @Test
     public void testParamJsScript() throws Exception {
         ZestActionInvoke inv = new ZestActionInvoke();
@@ -77,11 +67,6 @@ public class ZestActionInvokeUnitTest {
         assertEquals("PQRST", result);
     }
 
-    /**
-     * Method testSimpleZestScript.
-     *
-     * @throws Exception
-     */
     @Test
     public void testSimpleZestScript() throws Exception {
         ZestActionInvoke inv = new ZestActionInvoke();
@@ -98,11 +83,6 @@ public class ZestActionInvokeUnitTest {
         assertEquals("ABCDE", result);
     }
 
-    /**
-     * Method testAssignZestScript.
-     *
-     * @throws Exception
-     */
     @Test
     public void testAssignZestScript() throws Exception {
         ZestActionInvoke inv = new ZestActionInvoke();
@@ -119,11 +99,6 @@ public class ZestActionInvokeUnitTest {
         assertEquals("EFGHI", result);
     }
 
-    /**
-     * Method testParamZestScript.
-     *
-     * @throws Exception
-     */
     @Test
     public void testParamZestScript() throws Exception {
         ZestActionInvoke inv = new ZestActionInvoke();

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssertBodyRegexUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssertBodyRegexUnitTest.java
@@ -15,37 +15,22 @@ import org.mozilla.zest.core.v1.ZestVariables;
 /** */
 public class ZestAssertBodyRegexUnitTest {
 
-    /**
-     * Method testSimpleIncRegex.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testSimpleIncRegex() throws Exception {
+    public void testSimpleIncRegex() {
         ZestExpressionRegex regex = new ZestExpressionRegex(ZestVariables.RESPONSE_BODY, "test123");
         ZestAssertion ze = new ZestAssertion(regex);
         assertTrue(ze.isValid(new TestRuntime(new ZestResponse(null, "", "aaaatest123", 200, 0))));
     }
 
-    /**
-     * Method testSimpleExcRegex.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testSimpleExcRegex() throws Exception {
+    public void testSimpleExcRegex() {
         ZestExpressionRegex regex = new ZestExpressionRegex(ZestVariables.RESPONSE_BODY, "test123");
         ZestAssertion ze = new ZestAssertion(regex);
         assertFalse(ze.isValid(new TestRuntime(new ZestResponse(null, "", "aaaatst123", 200, 0))));
     }
 
-    /**
-     * Method testSimpleIncInvRegex.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testSimpleIncInvRegex() throws Exception {
+    public void testSimpleIncInvRegex() {
         ZestExpressionRegex regex =
                 new ZestExpressionRegex(ZestVariables.RESPONSE_BODY, "test123", false, true);
         ZestAssertion ze = new ZestAssertion(regex);
@@ -53,7 +38,7 @@ public class ZestAssertBodyRegexUnitTest {
     }
 
     @Test
-    public void testSimpleCaseExact() throws Exception {
+    public void testSimpleCaseExact() {
         ZestExpressionRegex regex =
                 new ZestExpressionRegex(ZestVariables.RESPONSE_BODY, "test123", true, false);
         ZestAssertion ze = new ZestAssertion(regex);
@@ -62,7 +47,7 @@ public class ZestAssertBodyRegexUnitTest {
     }
 
     @Test
-    public void testSimpleCaseIgnore() throws Exception {
+    public void testSimpleCaseIgnore() {
         ZestExpressionRegex regex =
                 new ZestExpressionRegex(ZestVariables.RESPONSE_BODY, "test123", false, false);
         ZestAssertion ze = new ZestAssertion(regex);
@@ -70,13 +55,8 @@ public class ZestAssertBodyRegexUnitTest {
         assertTrue(ze.isValid(new TestRuntime(new ZestResponse(null, "", "aaaaTest123", 200, 0))));
     }
 
-    /**
-     * Method testSimpleExcInvRegex.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testSimpleExcInvRegex() throws Exception {
+    public void testSimpleExcInvRegex() {
         ZestExpressionRegex regex =
                 new ZestExpressionRegex(ZestVariables.RESPONSE_BODY, "test123", false, true);
         ZestAssertion ze = new ZestAssertion(regex);

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignCalcUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignCalcUnitTest.java
@@ -13,7 +13,7 @@ import org.mozilla.zest.core.v1.ZestAssignFailException;
 public class ZestAssignCalcUnitTest {
 
     @Test
-    public void shouldBePassiveZestStatement() throws Exception {
+    public void shouldBePassiveZestStatement() {
         // Given / When
         ZestAssignCalc assignCalc = new ZestAssignCalc();
         // Then
@@ -21,7 +21,7 @@ public class ZestAssignCalcUnitTest {
     }
 
     @Test
-    public void shouldHaveNoVariableNameByDefault() throws Exception {
+    public void shouldHaveNoVariableNameByDefault() {
         // Given / When
         ZestAssignCalc assignCalc = new ZestAssignCalc();
         // Then
@@ -29,7 +29,7 @@ public class ZestAssignCalcUnitTest {
     }
 
     @Test
-    public void shouldBeEnabledByDefault() throws Exception {
+    public void shouldBeEnabledByDefault() {
         // Given / When
         ZestAssignCalc assignCalc = new ZestAssignCalc();
         // Then
@@ -37,7 +37,7 @@ public class ZestAssignCalcUnitTest {
     }
 
     @Test
-    public void shouldHaveNoOperandsNorOperationByDefault() throws Exception {
+    public void shouldHaveNoOperandsNorOperationByDefault() {
         // Given / When
         ZestAssignCalc assignCalc = new ZestAssignCalc();
         // Then
@@ -47,7 +47,7 @@ public class ZestAssignCalcUnitTest {
     }
 
     @Test
-    public void shouldConstructWithVariableName() throws Exception {
+    public void shouldConstructWithVariableName() {
         // Given
         String variableName = "Var1";
         // When
@@ -57,7 +57,7 @@ public class ZestAssignCalcUnitTest {
     }
 
     @Test
-    public void shouldConstructWithVariableNameOperandsAndOperation() throws Exception {
+    public void shouldConstructWithVariableNameOperandsAndOperation() {
         // Given
         String variableName = "Var2";
         String operandA = "1";
@@ -73,7 +73,7 @@ public class ZestAssignCalcUnitTest {
     }
 
     @Test
-    public void shouldSetVariableName() throws Exception {
+    public void shouldSetVariableName() {
         // Given
         String variableName = "Var3";
         ZestAssignCalc assignCalc = new ZestAssignCalc();
@@ -84,7 +84,7 @@ public class ZestAssignCalcUnitTest {
     }
 
     @Test
-    public void shouldSetNullVariableName() throws Exception {
+    public void shouldSetNullVariableName() {
         // Given
         String variableName = null;
         ZestAssignCalc assignCalc = new ZestAssignCalc();
@@ -95,7 +95,7 @@ public class ZestAssignCalcUnitTest {
     }
 
     @Test
-    public void shouldSetEnabledState() throws Exception {
+    public void shouldSetEnabledState() {
         // Given
         boolean enabled = false;
         ZestAssignCalc assignCalc = new ZestAssignCalc();
@@ -106,7 +106,7 @@ public class ZestAssignCalcUnitTest {
     }
 
     @Test
-    public void shouldSetOperandA() throws Exception {
+    public void shouldSetOperandA() {
         // Given
         String operandA = "3";
         ZestAssignCalc assignCalc = new ZestAssignCalc();
@@ -117,7 +117,7 @@ public class ZestAssignCalcUnitTest {
     }
 
     @Test
-    public void shouldSetKnownOperation() throws Exception {
+    public void shouldSetKnownOperation() {
         // Given
         String operation = ZestAssignCalc.OPERAND_SUBTRACT;
         ZestAssignCalc assignCalc = new ZestAssignCalc();
@@ -128,7 +128,7 @@ public class ZestAssignCalcUnitTest {
     }
 
     @Test
-    public void shouldSetUnknownOperation() throws Exception {
+    public void shouldSetUnknownOperation() {
         // Given
         String operation = "unknown";
         ZestAssignCalc assignCalc = new ZestAssignCalc();
@@ -139,7 +139,7 @@ public class ZestAssignCalcUnitTest {
     }
 
     @Test
-    public void shouldSetOperandB() throws Exception {
+    public void shouldSetOperandB() {
         // Given
         String operandB = "4";
         ZestAssignCalc assignCalc = new ZestAssignCalc();
@@ -150,7 +150,7 @@ public class ZestAssignCalcUnitTest {
     }
 
     @Test
-    public void shouldDeepCopy() throws Exception {
+    public void shouldDeepCopy() {
         // Given
         String variableName = "Var4";
         String operandA = "5";

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignStringUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignStringUnitTest.java
@@ -13,13 +13,8 @@ import org.mozilla.zest.core.v1.ZestResponse;
 /** */
 public class ZestAssignStringUnitTest {
 
-    /**
-     * Method testSimpleCase.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testSimpleCase() throws Exception {
+    public void testSimpleCase() {
         ZestAssignString ast = new ZestAssignString();
         TestRuntime rt = new TestRuntime();
         ZestResponse resp =
@@ -32,13 +27,8 @@ public class ZestAssignStringUnitTest {
         assertEquals(test1, ast.assign(resp, rt));
     }
 
-    /**
-     * Method testRegexes.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testVariables() throws Exception {
+    public void testVariables() {
         ZestAssignString ast = new ZestAssignString();
         TestRuntime rt = new TestRuntime();
 
@@ -67,7 +57,7 @@ public class ZestAssignStringUnitTest {
     }
 
     @Test
-    public void testRecurse() throws Exception {
+    public void testRecurse() {
         ZestAssignString ast = new ZestAssignString();
         TestRuntime rt = new TestRuntime();
 

--- a/src/test/java/org/mozilla/zest/test/v1/ZestClientLaunchUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestClientLaunchUnitTest.java
@@ -33,7 +33,7 @@ public class ZestClientLaunchUnitTest extends ServerBasedTest {
     }
 
     @Test
-    public void shouldUseArgsPassedInConstructor() throws Exception {
+    public void shouldUseArgsPassedInConstructor() {
         // Given
         String windowHandle = "windowHandle";
         String browserType = "browserType";
@@ -48,7 +48,7 @@ public class ZestClientLaunchUnitTest extends ServerBasedTest {
     }
 
     @Test
-    public void shouldUseArgsPassedInConstructorWithCapabilities() throws Exception {
+    public void shouldUseArgsPassedInConstructorWithCapabilities() {
         // Given
         String windowHandle = "windowHandle";
         String browserType = "browserType";
@@ -132,7 +132,7 @@ public class ZestClientLaunchUnitTest extends ServerBasedTest {
     }
 
     @Test
-    public void shouldDeepCopy() throws Exception {
+    public void shouldDeepCopy() {
         // Given
         ZestClientLaunch original =
                 new ZestClientLaunch("handle", "browser", "url", "capabilities", false, "/profile");

--- a/src/test/java/org/mozilla/zest/test/v1/ZestClientScreenshotUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestClientScreenshotUnitTest.java
@@ -291,7 +291,7 @@ public class ZestClientScreenshotUnitTest {
     }
 
     @Test
-    public void shouldDeepCopy() throws Exception {
+    public void shouldDeepCopy() {
         // Given
         ZestClientScreenshot original =
                 new ZestClientScreenshot("windowHandle", "/path", "variableName");

--- a/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexExprUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexExprUnitTest.java
@@ -14,13 +14,8 @@ import org.mozilla.zest.core.v1.ZestStatement;
 /** */
 public class ZestConditionalRegexExprUnitTest {
 
-    /**
-     * Method testAddingIfs.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testAddingIfs() throws Exception {
+    public void testAddingIfs() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
 
         ZestRequest req = new ZestRequest();
@@ -44,13 +39,8 @@ public class ZestConditionalRegexExprUnitTest {
         checkOrder(new ZestStatement[] {zc, req, req3, req2, null});
     }
 
-    /**
-     * Method testRemoveFirstIf.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testRemoveFirstIf() throws Exception {
+    public void testRemoveFirstIf() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -64,13 +54,8 @@ public class ZestConditionalRegexExprUnitTest {
         checkOrder(new ZestStatement[] {zc, req2, req3, null});
     }
 
-    /**
-     * Method testRemoveMiddleIf.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testRemoveMiddleIf() throws Exception {
+    public void testRemoveMiddleIf() {
 
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
@@ -85,13 +70,8 @@ public class ZestConditionalRegexExprUnitTest {
         checkOrder(new ZestStatement[] {zc, req1, req3, null});
     }
 
-    /**
-     * Method testRemoveLastIf.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testRemoveLastIf() throws Exception {
+    public void testRemoveLastIf() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -105,13 +85,8 @@ public class ZestConditionalRegexExprUnitTest {
         checkOrder(new ZestStatement[] {zc, req1, req2, null});
     }
 
-    /**
-     * Method testMoveFirstIf.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testMoveFirstIf() throws Exception {
+    public void testMoveFirstIf() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -125,13 +100,8 @@ public class ZestConditionalRegexExprUnitTest {
         checkOrder(new ZestStatement[] {zc, req2, req3, req1, null});
     }
 
-    /**
-     * Method testMoveSecondIf.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testMoveSecondIf() throws Exception {
+    public void testMoveSecondIf() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -146,13 +116,8 @@ public class ZestConditionalRegexExprUnitTest {
         checkOrder(new ZestStatement[] {zc, req2, req1, req3, null});
     }
 
-    /**
-     * Method testMoveLastIf.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testMoveLastIf() throws Exception {
+    public void testMoveLastIf() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -166,13 +131,8 @@ public class ZestConditionalRegexExprUnitTest {
         checkOrder(new ZestStatement[] {zc, req1, req3, req2, null});
     }
 
-    /**
-     * Method testAddingElses.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testAddingElses() throws Exception {
+    public void testAddingElses() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
 
         ZestRequest req = new ZestRequest();
@@ -196,13 +156,8 @@ public class ZestConditionalRegexExprUnitTest {
         checkOrder(new ZestStatement[] {zc, req, req3, req2, null});
     }
 
-    /**
-     * Method testRemoveFirstElse.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testRemoveFirstElse() throws Exception {
+    public void testRemoveFirstElse() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -216,13 +171,8 @@ public class ZestConditionalRegexExprUnitTest {
         checkOrder(new ZestStatement[] {zc, req2, req3, null});
     }
 
-    /**
-     * Method testRemoveMiddleElse.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testRemoveMiddleElse() throws Exception {
+    public void testRemoveMiddleElse() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -236,13 +186,8 @@ public class ZestConditionalRegexExprUnitTest {
         checkOrder(new ZestStatement[] {zc, req1, req3, null});
     }
 
-    /**
-     * Method testRemoveLastElse.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testRemoveLastElse() throws Exception {
+    public void testRemoveLastElse() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -256,13 +201,8 @@ public class ZestConditionalRegexExprUnitTest {
         checkOrder(new ZestStatement[] {zc, req1, req2, null});
     }
 
-    /**
-     * Method testMoveFirstElse.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testMoveFirstElse() throws Exception {
+    public void testMoveFirstElse() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -276,13 +216,8 @@ public class ZestConditionalRegexExprUnitTest {
         checkOrder(new ZestStatement[] {zc, req2, req1, req3, null});
     }
 
-    /**
-     * Method testMoveSecondElse.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testMoveSecondElse() throws Exception {
+    public void testMoveSecondElse() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -296,13 +231,8 @@ public class ZestConditionalRegexExprUnitTest {
         checkOrder(new ZestStatement[] {zc, req1, req3, req2, null});
     }
 
-    /**
-     * Method testMoveLastElse.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testMoveLastElse() throws Exception {
+    public void testMoveLastElse() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -316,13 +246,8 @@ public class ZestConditionalRegexExprUnitTest {
         checkOrder(new ZestStatement[] {zc, req3, req1, req2, null});
     }
 
-    /**
-     * Method testDeepConditionals1.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testDeepConditionals1() throws Exception {
+    public void testDeepConditionals1() {
         ZestConditional zc1 = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestConditional zc2 = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
@@ -334,13 +259,8 @@ public class ZestConditionalRegexExprUnitTest {
         checkOrder(new ZestStatement[] {zc1, zc2, req1, req2, null});
     }
 
-    /**
-     * Method testDeepConditionals2.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testDeepConditionals2() throws Exception {
+    public void testDeepConditionals2() {
         ZestConditional zc1 = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestConditional zc2 = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestConditional zc3 = new ZestConditional(new ZestExpressionRegex("BODY", ""));

--- a/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexUnitTest.java
@@ -15,13 +15,8 @@ import org.mozilla.zest.core.v1.ZestStatement;
 /** */
 public class ZestConditionalRegexUnitTest {
 
-    /**
-     * Method testAddingIfs.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testAddingIfs() throws Exception {
+    public void testAddingIfs() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
 
         ZestRequest req = new ZestRequest();
@@ -45,13 +40,8 @@ public class ZestConditionalRegexUnitTest {
         checkOrder(new ZestStatement[] {zc, req, req3, req2, null});
     }
 
-    /**
-     * Method testRemoveFirstIf.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testRemoveFirstIf() throws Exception {
+    public void testRemoveFirstIf() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -65,13 +55,8 @@ public class ZestConditionalRegexUnitTest {
         checkOrder(new ZestStatement[] {zc, req2, req3, null});
     }
 
-    /**
-     * Method testRemoveMiddleIf.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testRemoveMiddleIf() throws Exception {
+    public void testRemoveMiddleIf() {
 
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
@@ -86,13 +71,8 @@ public class ZestConditionalRegexUnitTest {
         checkOrder(new ZestStatement[] {zc, req1, req3, null});
     }
 
-    /**
-     * Method testRemoveLastIf.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testRemoveLastIf() throws Exception {
+    public void testRemoveLastIf() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -106,13 +86,8 @@ public class ZestConditionalRegexUnitTest {
         checkOrder(new ZestStatement[] {zc, req1, req2, null});
     }
 
-    /**
-     * Method testMoveFirstIf.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testMoveFirstIf() throws Exception {
+    public void testMoveFirstIf() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -126,13 +101,8 @@ public class ZestConditionalRegexUnitTest {
         checkOrder(new ZestStatement[] {zc, req2, req3, req1, null});
     }
 
-    /**
-     * Method testMoveSecondIf.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testMoveSecondIf() throws Exception {
+    public void testMoveSecondIf() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -147,13 +117,8 @@ public class ZestConditionalRegexUnitTest {
         checkOrder(new ZestStatement[] {zc, req2, req1, req3, null});
     }
 
-    /**
-     * Method testMoveLastIf.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testMoveLastIf() throws Exception {
+    public void testMoveLastIf() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -167,13 +132,8 @@ public class ZestConditionalRegexUnitTest {
         checkOrder(new ZestStatement[] {zc, req1, req3, req2, null});
     }
 
-    /**
-     * Method testAddingElses.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testAddingElses() throws Exception {
+    public void testAddingElses() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
 
         ZestRequest req = new ZestRequest();
@@ -197,13 +157,8 @@ public class ZestConditionalRegexUnitTest {
         checkOrder(new ZestStatement[] {zc, req, req3, req2, null});
     }
 
-    /**
-     * Method testRemoveFirstElse.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testRemoveFirstElse() throws Exception {
+    public void testRemoveFirstElse() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -217,13 +172,8 @@ public class ZestConditionalRegexUnitTest {
         checkOrder(new ZestStatement[] {zc, req2, req3, null});
     }
 
-    /**
-     * Method testRemoveMiddleElse.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testRemoveMiddleElse() throws Exception {
+    public void testRemoveMiddleElse() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -237,13 +187,8 @@ public class ZestConditionalRegexUnitTest {
         checkOrder(new ZestStatement[] {zc, req1, req3, null});
     }
 
-    /**
-     * Method testRemoveLastElse.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testRemoveLastElse() throws Exception {
+    public void testRemoveLastElse() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -257,13 +202,8 @@ public class ZestConditionalRegexUnitTest {
         checkOrder(new ZestStatement[] {zc, req1, req2, null});
     }
 
-    /**
-     * Method testMoveFirstElse.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testMoveFirstElse() throws Exception {
+    public void testMoveFirstElse() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -277,13 +217,8 @@ public class ZestConditionalRegexUnitTest {
         checkOrder(new ZestStatement[] {zc, req2, req1, req3, null});
     }
 
-    /**
-     * Method testMoveSecondElse.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testMoveSecondElse() throws Exception {
+    public void testMoveSecondElse() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -297,13 +232,8 @@ public class ZestConditionalRegexUnitTest {
         checkOrder(new ZestStatement[] {zc, req1, req3, req2, null});
     }
 
-    /**
-     * Method testMoveLastElse.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testMoveLastElse() throws Exception {
+    public void testMoveLastElse() {
         ZestConditional zc = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -317,13 +247,8 @@ public class ZestConditionalRegexUnitTest {
         checkOrder(new ZestStatement[] {zc, req3, req1, req2, null});
     }
 
-    /**
-     * Method testDeepConditionals1.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testDeepConditionals1() throws Exception {
+    public void testDeepConditionals1() {
         ZestConditional zc1 = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestConditional zc2 = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
@@ -335,13 +260,8 @@ public class ZestConditionalRegexUnitTest {
         checkOrder(new ZestStatement[] {zc1, zc2, req1, req2, null});
     }
 
-    /**
-     * Method testDeepConditionals2.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testDeepConditionals2() throws Exception {
+    public void testDeepConditionals2() {
         ZestConditional zc1 = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestConditional zc2 = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestConditional zc3 = new ZestConditional(new ZestExpressionRegex("BODY", ""));
@@ -401,13 +321,8 @@ public class ZestConditionalRegexUnitTest {
         checkOrder(new ZestStatement[] {zc1, req1, zc2, req2, req3, req5, zc4, req6, null});
     }
 
-    /**
-     * Method testMovingIfStatements.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testMovingIfStatements() throws Exception {
+    public void testMovingIfStatements() {
         ZestScript zs = new ZestScript();
         ZestConditional zc1 = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
@@ -422,13 +337,8 @@ public class ZestConditionalRegexUnitTest {
         checkOrder(new ZestStatement[] {zs, zc1, req2, req1, null});
     }
 
-    /**
-     * Method testMovingElseStatements.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testMovingElseStatements() throws Exception {
+    public void testMovingElseStatements() {
         ZestConditional zc1 = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestRequest req1 = new ZestRequest();
         ZestRequest req2 = new ZestRequest();
@@ -442,7 +352,7 @@ public class ZestConditionalRegexUnitTest {
     }
     /*
     	@Test
-    	public void testDepthIndexing() throws Exception {
+    	public void testDepthIndexing() {
     System.out.println("Failing test .........");
     		ZestScript script = new ZestScript();
     		ZestRequest req = new ZestRequest();

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionProtocolUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionProtocolUnitTest.java
@@ -78,7 +78,7 @@ public class ZestExpressionProtocolUnitTest {
     }
 
     @Test
-    public void shouldEvaluateToFalseIfNoRequest() throws Exception {
+    public void shouldEvaluateToFalseIfNoRequest() {
         // Given
         ZestExpressionProtocol protocolExpression = new ZestExpressionProtocol("http");
         // When
@@ -88,7 +88,7 @@ public class ZestExpressionProtocolUnitTest {
     }
 
     @Test
-    public void shouldEvaluateToFalseIfRequestButNoUrl() throws Exception {
+    public void shouldEvaluateToFalseIfRequestButNoUrl() {
         // Given
         ZestExpressionProtocol protocolExpression = new ZestExpressionProtocol("http");
         ZestRequest request = createRequest();

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionStatusCodeUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionStatusCodeUnitTest.java
@@ -67,7 +67,7 @@ public class ZestExpressionStatusCodeUnitTest {
     }
 
     @Test
-    public void shouldEvaluateToFalseIfNoResponse() throws Exception {
+    public void shouldEvaluateToFalseIfNoResponse() {
         // Given
         ZestExpressionStatusCode statusCodeExpression = new ZestExpressionStatusCode(204);
         // When

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopUnitTest.java
@@ -16,7 +16,7 @@ import org.mozilla.zest.core.v1.ZestStatement;
 public class ZestLoopUnitTest {
 
     @Test
-    public void shouldReturnEmptyListIfNoStatementsWhenCopyingStatements() throws Exception {
+    public void shouldReturnEmptyListIfNoStatementsWhenCopyingStatements() {
         // Given
         ZestLoop<String> loop = new ZestLoopTest();
         // When
@@ -26,7 +26,7 @@ public class ZestLoopUnitTest {
     }
 
     @Test
-    public void shouldReturnADifferentListAndStatementsWhenCopyingStatements() throws Exception {
+    public void shouldReturnADifferentListAndStatementsWhenCopyingStatements() {
         // Given
         ZestLoop<String> loop = new ZestLoopTest();
         loop.addStatement(new ZestComment());

--- a/src/test/java/org/mozilla/zest/test/v1/ZestScriptUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestScriptUnitTest.java
@@ -20,13 +20,8 @@ import org.mozilla.zest.core.v1.ZestVariables;
 /** */
 public class ZestScriptUnitTest {
 
-    /**
-     * Method testSimpleIndexing.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testSimpleIndexing() throws Exception {
+    public void testSimpleIndexing() {
         ZestScript script = new ZestScript();
         ZestRequest req = new ZestRequest();
         script.add(req);
@@ -41,13 +36,8 @@ public class ZestScriptUnitTest {
         checkOrder(new ZestStatement[] {script, req, req1b, req2, null});
     }
 
-    /**
-     * Method testDepthIndexing.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testDepthIndexing() throws Exception {
+    public void testDepthIndexing() {
         ZestScript script = new ZestScript();
         ZestRequest req = new ZestRequest();
         script.add(req);
@@ -90,13 +80,8 @@ public class ZestScriptUnitTest {
         checkOrder(new ZestStatement[] {script, req, cond1, req4, req3, req2, null});
     }
 
-    /**
-     * Method testDeepComplex.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testDeepComplex() throws Exception {
+    public void testDeepComplex() {
         ZestConditional zc1 = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestConditional zc2 = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestConditional zc3 = new ZestConditional(new ZestExpressionRegex("BODY", ""));
@@ -173,13 +158,8 @@ public class ZestScriptUnitTest {
         // assertEquals(req4.getIndex(), xfrm2.getRequestId());
     }
 
-    /**
-     * Method testDeepMiscOrder.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testDeepMiscOrder() throws Exception {
+    public void testDeepMiscOrder() {
         ZestScript script = new ZestScript();
         ZestConditional zc1 = new ZestConditional(new ZestExpressionRegex("BODY", ""));
         ZestConditional zc2 = new ZestConditional(new ZestExpressionRegex("BODY", ""));
@@ -251,13 +231,8 @@ public class ZestScriptUnitTest {
         }
     }
 
-    /**
-     * Method testSimpleIndexing.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testVariableNames() throws Exception {
+    public void testVariableNames() {
         ZestScript script = new ZestScript();
         // Check the default ones
         assertTrue(script.getVariableNames().contains(ZestVariables.REQUEST_HEADER));

--- a/src/test/java/org/mozilla/zest/test/v1/ZestVariableUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestVariableUnitTest.java
@@ -14,13 +14,8 @@ import org.mozilla.zest.core.v1.ZestScript;
 /** */
 public class ZestVariableUnitTest {
 
-    /**
-     * Method testTokenReplacement.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testAssign() throws Exception {
+    public void testAssign() {
         ZestScript script = new ZestScript();
         ZestAssignString ast = new ZestAssignString();
 

--- a/src/test/java/org/mozilla/zest/test/v1/ZestVariablesUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestVariablesUnitTest.java
@@ -21,7 +21,7 @@ public class ZestVariablesUnitTest {
     private static final String VAR_VALUE = "value";
 
     @Test
-    public void shouldHaveTokenStartByDefault() throws Exception {
+    public void shouldHaveTokenStartByDefault() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         // When
@@ -31,7 +31,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldHaveTokenEndByDefault() throws Exception {
+    public void shouldHaveTokenEndByDefault() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         // When
@@ -41,7 +41,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldHaveNoVariablesByDefault() throws Exception {
+    public void shouldHaveNoVariablesByDefault() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         // When
@@ -51,7 +51,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldSetTokenStart() throws Exception {
+    public void shouldSetTokenStart() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         String tokenStart = "\\|";
@@ -62,7 +62,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldSetTokenEnd() throws Exception {
+    public void shouldSetTokenEnd() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         String tokenEnd = "|//";
@@ -73,7 +73,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldAddVarWithNameAsValue() throws Exception {
+    public void shouldAddVarWithNameAsValue() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         // When
@@ -85,7 +85,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldAddVarWithValue() throws Exception {
+    public void shouldAddVarWithValue() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         // When
@@ -97,7 +97,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldAddVarWithNameAsValueIfValueIsNull() throws Exception {
+    public void shouldAddVarWithNameAsValueIfValueIsNull() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         String value = null;
@@ -110,7 +110,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldNotAddVarIfAlreadyAdded() throws Exception {
+    public void shouldNotAddVarIfAlreadyAdded() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         zestVars.addVariable(VAR_NAME);
@@ -123,7 +123,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldNotAddVarWithValueIfAlreadyAdded() throws Exception {
+    public void shouldNotAddVarWithValueIfAlreadyAdded() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         zestVars.addVariable(VAR_NAME);
@@ -136,7 +136,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldGetValueOfVariableAdded() throws Exception {
+    public void shouldGetValueOfVariableAdded() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         zestVars.addVariable(VAR_NAME, VAR_VALUE);
@@ -147,7 +147,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldGetNullValueIfVariableWasNotAdded() throws Exception {
+    public void shouldGetNullValueIfVariableWasNotAdded() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         // When
@@ -157,7 +157,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldSetVariables() throws Exception {
+    public void shouldSetVariables() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         Map<String, String> vars = new HashMap<>();
@@ -183,7 +183,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldSetVariable() throws Exception {
+    public void shouldSetVariable() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         // When
@@ -195,7 +195,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldSetVariableWithNullName() throws Exception {
+    public void shouldSetVariableWithNullName() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         String name = null;
@@ -208,7 +208,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldSetVariableWithNullValue() throws Exception {
+    public void shouldSetVariableWithNullValue() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         String value = null;
@@ -221,7 +221,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldAddVariables() throws Exception {
+    public void shouldAddVariables() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         Map<String, String> vars = new HashMap<>();
@@ -249,7 +249,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldReturnNullStringIfReplacingVariablesInNullString() throws Exception {
+    public void shouldReturnNullStringIfReplacingVariablesInNullString() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         // When
@@ -259,7 +259,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldReplaceVariablesInString() throws Exception {
+    public void shouldReplaceVariablesInString() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         zestVars.setVariable("Var1", "0");
@@ -279,7 +279,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldReplaceVariablesInVariablesInString() throws Exception {
+    public void shouldReplaceVariablesInVariablesInString() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         zestVars.setVariable("Var1", "-1 < " + token(zestVars, "Var2"));
@@ -293,7 +293,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldReplaceLoopingVariablesInVariablesInString() throws Exception {
+    public void shouldReplaceLoopingVariablesInVariablesInString() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         zestVars.setVariable("Var1", "No Loop: " + token(zestVars, "Var2"));
@@ -309,7 +309,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldReplaceEncodedVariablesInString() throws Exception {
+    public void shouldReplaceEncodedVariablesInString() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         zestVars.setVariable("Var%", "0");
@@ -330,7 +330,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldReplaceVariablesInEncodedVariablesInString() throws Exception {
+    public void shouldReplaceVariablesInEncodedVariablesInString() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         zestVars.setVariable("Var%", "-1 < " + token(zestVars, "Var&"));
@@ -346,7 +346,7 @@ public class ZestVariablesUnitTest {
     }
 
     @Test
-    public void shouldReplaceLoopingVariablesInEncodedVariablesInString() throws Exception {
+    public void shouldReplaceLoopingVariablesInEncodedVariablesInString() {
         // Given
         ZestVariables zestVars = new ZestVariables();
         zestVars.setVariable("Var1", "No Loop: " + token(zestVars, "Var2"));


### PR DESCRIPTION
Address SonarLint issues:
 - Simplify boolean checks in and/or Zest expressions.
 - Remove:
   - Redundant type arguments, method modifiers in interfaces, and
   JavaDoc in test methods;
   - Unnecessary semicolon and array instantiations (varargs);
   - Declaration of runtime exceptions and of exceptions not actually
  thrown;
 - Replace for loop with `Collections.addAll`;
 - Use same catch block.