### PR TITLE
Serialise dates with fixed format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update HTTP client implementation, use HttpComponents Client instead of Commons HttpClient. [#168](https://github.com/mozilla/zest/issues/168)
 - Update Selenium to 3.141.59. [#169](https://github.com/mozilla/zest/issues/169)
 - Keep proxying localhost with Chrome 72+ and Firefox 67+. [#197](https://github.com/mozilla/zest/pull/197)
+- Use ISO 8601 format to de/serialise dates from/to JSON, to not depend on the system the script is running. [#202](https://github.com/mozilla/zest/pull/202)
 
 ### Removed
 - Remove dependency on Commons HttpClient, the client implementation, and related methods. [#136](https://github.com/mozilla/zest/pull/136)


### PR DESCRIPTION
Use ISO 8601 format (date/time, UTC) to de/serialise dates from/to JSON,
to not depend on the system's locale/timezone the script is running.