### PR TITLE
Use HTTPS for the license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -357,7 +357,7 @@ Exhibit A - Source Code Form License Notice
 
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 If it is not possible or desirable to put the notice in a particular
 file, then You may include the notice in a location (such as a LICENSE

--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,7 @@ publishing {
                 licenses {
                     license {
                         name = 'Mozilla Public License Version 2.0'
-                        url = 'http://mozilla.org/MPL/2.0/'
+                        url = 'https://mozilla.org/MPL/2.0/'
                         distribution = 'repo'
                     }
                 }

--- a/gradle/spotless/license.java
+++ b/gradle/spotless/license.java
@@ -1,3 +1,3 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAction.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAction.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionFail.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionFail.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionFailException.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionFailException.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionGlobalVariableRemove.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionGlobalVariableRemove.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionGlobalVariableSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionGlobalVariableSet.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionIntercept.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionIntercept.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionInvoke.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionInvoke.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.io.BufferedReader;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionPrint.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionPrint.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /** The Class ZestActionPrint. */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionScan.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionScan.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestActionSleep.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestActionSleep.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /** The Class ZestActionPrint. */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssertFailException.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssertFailException.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssertion.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssertion.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignCalc.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignCalc.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignFailException.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignFailException.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignFieldValue.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignFieldValue.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.List;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignFromElement.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignFromElement.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.ArrayList;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignGlobalVariable.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignGlobalVariable.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignRandomInteger.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignRandomInteger.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.security.SecureRandom;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignRegexDelimiters.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignRegexDelimiters.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.Arrays;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignReplace.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignReplace.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.regex.Pattern;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignString.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignString.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignStringDelimiters.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignStringDelimiters.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.Arrays;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAssignment.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAssignment.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestAuthentication.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestAuthentication.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /** The Class ZestAuthentication. */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClient.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClient.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /** An abstract class that all client related statements extend. */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientAssignCookie.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientAssignCookie.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import org.openqa.selenium.Cookie;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientElement.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientElement.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import org.openqa.selenium.By;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientElementAssign.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientElementAssign.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientElementClear.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientElementClear.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientElementClick.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientElementClick.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientElementSendKeys.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientElementSendKeys.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientElementSubmit.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientElementSubmit.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientFailException.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientFailException.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /** The Class ZestClientFailException. */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientLaunch.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientLaunch.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import com.machinepublishers.jbrowserdriver.JBrowserDriver;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientScreenshot.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientScreenshot.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.io.ByteArrayInputStream;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientSwitchToFrame.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientSwitchToFrame.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import org.openqa.selenium.WebDriver;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientWindowClose.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientWindowClose.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import org.openqa.selenium.WebDriver;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientWindowHandle.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientWindowHandle.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.regex.Pattern;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestClientWindowOpenUrl.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestClientWindowOpenUrl.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import org.openqa.selenium.WebDriver;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestComment.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestComment.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /** Exits the script returning a string. */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestConditional.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestConditional.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestContainer.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestContainer.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.List;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestControl.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestControl.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /** An abstract class representing statements that change the flow of statements */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestControlLoopBreak.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestControlLoopBreak.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestControlLoopNext.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestControlLoopNext.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestControlReturn.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestControlReturn.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /** Exits the script returning a string. */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestCookie.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestCookie.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.Date;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestElement.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestElement.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.security.InvalidParameterException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpression.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpression.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionAnd.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionAnd.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.LinkedList;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionClientElementExists.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionClientElementExists.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import org.openqa.selenium.By;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionElement.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionElement.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionEquals.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionEquals.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /** The Class ZestExpressionRegex. */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionIsInteger.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionIsInteger.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /** Represent an expression that tests to see if a variable value is an integer. */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionLength.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionLength.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionOr.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionOr.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.LinkedList;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionProtocol.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionProtocol.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.net.URL;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionRegex.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionRegex.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.regex.Pattern;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionResponseTime.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionResponseTime.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionStatusCode.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionStatusCode.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestExpressionURL.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestExpressionURL.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.ArrayList;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestFieldDefinition.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestFieldDefinition.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestHttpAuthentication.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestHttpAuthentication.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestInvalidCommonTestException.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestInvalidCommonTestException.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestJSON.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestJSON.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import com.google.gson.Gson;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoop.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoop.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopClientElements.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopClientElements.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /** This class represent a loop through a set of client elements */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopFile.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopFile.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.io.File;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopInteger.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopInteger.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.LinkedList;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopRegex.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopRegex.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /**

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopState.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopState.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateClientElements.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateClientElements.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /** The Class ZestLoopStateFile. */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateFile.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateFile.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /** The Class ZestLoopStateFile. */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateInteger.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateInteger.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /** The Class ZestLoopStateInteger. */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateRegex.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateRegex.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /** The Class ZestLoopStateFile. */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateString.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopStateString.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /** The Class ZestLoopStateString. */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopString.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopString.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.LinkedList;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenClientElementsSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenClientElementsSet.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.Collections;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenFileSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenFileSet.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.io.File;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenIntegerSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenIntegerSet.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /** The Class ZestLoopTokenIntegerSet. */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenRegexSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenRegexSet.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.Collections;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenSet.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 // TODO: Auto-generated Javadoc

--- a/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenStringSet.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestLoopTokenStringSet.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.Collections;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestOutputWriter.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestOutputWriter.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 /** @since 0.14.0 */

--- a/src/main/java/org/mozilla/zest/core/v1/ZestRequest.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestRequest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestResponse.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestResponse.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.net.URL;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestRunner.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestRunner.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.io.IOException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestRuntime.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestRuntime.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.List;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestScript.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestScript.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestStatement.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestStatement.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.net.MalformedURLException;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestStructuredExpression.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestStructuredExpression.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.util.Collection;

--- a/src/main/java/org/mozilla/zest/core/v1/ZestVariables.java
+++ b/src/main/java/org/mozilla/zest/core/v1/ZestVariables.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.core.v1;
 
 import java.io.UnsupportedEncodingException;

--- a/src/main/java/org/mozilla/zest/impl/CmdLine.java
+++ b/src/main/java/org/mozilla/zest/impl/CmdLine.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.impl;
 
 import java.io.BufferedReader;

--- a/src/main/java/org/mozilla/zest/impl/ComponentsHttpClient.java
+++ b/src/main/java/org/mozilla/zest/impl/ComponentsHttpClient.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.impl;
 
 import java.io.IOException;

--- a/src/main/java/org/mozilla/zest/impl/ZestBasicRunner.java
+++ b/src/main/java/org/mozilla/zest/impl/ZestBasicRunner.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.impl;
 
 import java.io.BufferedReader;

--- a/src/main/java/org/mozilla/zest/impl/ZestHttpClient.java
+++ b/src/main/java/org/mozilla/zest/impl/ZestHttpClient.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.impl;
 
 import java.io.IOException;

--- a/src/main/java/org/mozilla/zest/impl/ZestPrinter.java
+++ b/src/main/java/org/mozilla/zest/impl/ZestPrinter.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.impl;
 
 import org.mozilla.zest.core.v1.ZestAction;

--- a/src/main/java/org/mozilla/zest/impl/ZestScriptEngine.java
+++ b/src/main/java/org/mozilla/zest/impl/ZestScriptEngine.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.impl;
 
 import java.io.Reader;

--- a/src/main/java/org/mozilla/zest/impl/ZestScriptEngineFactory.java
+++ b/src/main/java/org/mozilla/zest/impl/ZestScriptEngineFactory.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.impl;
 
 import java.util.ArrayList;

--- a/src/main/java/org/mozilla/zest/impl/ZestUtils.java
+++ b/src/main/java/org/mozilla/zest/impl/ZestUtils.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.impl;
 
 import java.util.ArrayList;

--- a/src/test/java/org/mozilla/zest/test/v1/ServerBasedTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ServerBasedTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;

--- a/src/test/java/org/mozilla/zest/test/v1/TestPrint.java
+++ b/src/test/java/org/mozilla/zest/test/v1/TestPrint.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import java.io.FileNotFoundException;

--- a/src/test/java/org/mozilla/zest/test/v1/TestRuntime.java
+++ b/src/test/java/org/mozilla/zest/test/v1/TestRuntime.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import java.util.List;

--- a/src/test/java/org/mozilla/zest/test/v1/TestSerializationScriptWithLoop.java
+++ b/src/test/java/org/mozilla/zest/test/v1/TestSerializationScriptWithLoop.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import java.io.FileNotFoundException;

--- a/src/test/java/org/mozilla/zest/test/v1/TestZestScriptWithLoop.java
+++ b/src/test/java/org/mozilla/zest/test/v1/TestZestScriptWithLoop.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import java.io.IOException;

--- a/src/test/java/org/mozilla/zest/test/v1/VerifyExamples.java
+++ b/src/test/java/org/mozilla/zest/test/v1/VerifyExamples.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestActionInvokeUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestActionInvokeUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestActionSleepUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestActionSleepUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssertBodyRegexUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssertBodyRegexUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignCalcUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignCalcUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignFieldValueUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignFieldValueUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import org.junit.Test;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignFromElementTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignFromElementTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignRegexDelimitersUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignRegexDelimitersUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignReplaceUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignReplaceUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignStringDelimitersUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignStringDelimitersUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestAssignStringUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestAssignStringUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestBasicRunnerUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestBasicRunnerUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestClientLaunchUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestClientLaunchUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestClientScreenshotUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestClientScreenshotUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestClientWindowOpenUrlUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestClientWindowOpenUrlUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import org.junit.Test;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexComplexUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexComplexUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import org.junit.Test;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexExprUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexExprUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestConditionalRegexUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionAndUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionAndUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionIsIntegerUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionIsIntegerUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionLengthUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionLengthUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionProtocolUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionProtocolUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionRegexUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionRegexUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionResponseTimeUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionResponseTimeUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionStatusCodeUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionStatusCodeUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestExpressionURLUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestExpressionURLUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopClientElementUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopClientElementUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopFileUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopFileUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import java.io.File;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopIntegerUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopIntegerUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopSerializationUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopSerializationUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopStateUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopStateUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopStringUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopStringUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopTokenSetUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopTokenSetUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestLoopUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestLoopUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestRequestUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestRequestUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestScriptUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestScriptUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestStructuredExpressionUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestStructuredExpressionUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestVariableUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestVariableUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/org/mozilla/zest/test/v1/ZestVariablesUnitTest.java
+++ b/src/test/java/org/mozilla/zest/test/v1/ZestVariablesUnitTest.java
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.mozilla.zest.test.v1;
 
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
Change license header and other license links to use HTTPS.