### PR TITLE
Restore proyxing capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Restore proxying capability, in the previous version the proxy settings were ignored. [#209](https://github.com/mozilla/zest/pull/209)
 
 ## [0.14.0] - 2019-11-07
 ### Fixed


### PR DESCRIPTION
Change `ComponentsHttpClient` to use a request config with the proxy
settings instead of setting to the context, the latter is ignored when
there's a request config.
Add test to assert that the request is proxied.

---
Reported in OWASP ZAP User Group: https://groups.google.com/d/topic/zaproxy-users/BzN_pJRiIZM/discussion