### PR TITLE
Correct cert checks and release 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
+## [0.14.2] - 2020-01-24
+### Fixed
+- Trust all certs when ignoring certificate checks, not just self signed. [#212](https://github.com/mozilla/zest/pull/212)
 
 ## [0.14.1] - 2020-01-15
 ### Fixed
@@ -60,7 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3] - 2013-09-10
 ## [0.2] - 2013-07-18
 
-[Unreleased]: https://github.com/mozilla/zest/compare/0.14.1...HEAD
+[0.14.2]: https://github.com/mozilla/zest/compare/0.14.1...0.14.2
 [0.14.1]: https://github.com/mozilla/zest/compare/0.14.0...0.14.1
 [0.14.0]: https://github.com/mozilla/zest/compare/0.13...0.14.0
 [0.13]: https://github.com/mozilla/zest/compare/0.12...0.13

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If using a dependency management tool, for example [Maven](https://maven.apache.
 
  * GroupId: `org.mozilla`
  * ArtifactId: `zest`
- * Version: `0.14.1`
+ * Version: `0.14.2`
 
 ## Building
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 group 'org.mozilla'
-version '0.15.0-SNAPSHOT'
+version '0.14.2'
 
 mainClassName = 'org.mozilla.zest.impl.CmdLine'
 

--- a/src/main/java/org/mozilla/zest/impl/ComponentsHttpClient.java
+++ b/src/main/java/org/mozilla/zest/impl/ComponentsHttpClient.java
@@ -29,7 +29,7 @@ import org.apache.http.client.methods.HttpTrace;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.TrustAllStrategy;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.BasicCredentialsProvider;
@@ -88,9 +88,7 @@ class ComponentsHttpClient implements ZestHttpClient {
             SSLContext sslContext;
             try {
                 sslContext =
-                        SSLContexts.custom()
-                                .loadTrustMaterial(TrustSelfSignedStrategy.INSTANCE)
-                                .build();
+                        SSLContexts.custom().loadTrustMaterial(TrustAllStrategy.INSTANCE).build();
             } catch (Exception e) {
                 // there should be no exception as we don't load key material and the algorithm is
                 // built-in


### PR DESCRIPTION
Trust all certs when ignoring certificate checks, not just self signed.
Set version to 0.14.2.
Update changelog and readme.